### PR TITLE
Add sync-seed release endpoint for self-hosted device sync

### DIFF
--- a/app/Http/Controllers/SeedReleaseController.php
+++ b/app/Http/Controllers/SeedReleaseController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\SyncSeed;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Seed-release endpoint — the linchpin of identity-gated sync.
+ *
+ * Returns the authenticated user's sync-chain seed, generating it on first use.
+ * The device turns this seed into (a) the go-sync self-signed auth token and
+ * (b) the client-side encryption key — and, in the final phase, the cryptohome
+ * disk key. The same user yields the same seed on every device, which is what
+ * makes "powerwash -> sign in -> fully-synced slate" work.
+ *
+ * Gated by the `sync` scope (mirrors UserinfoController's `openid` check). The
+ * sync wire itself is NOT protected here — it's network-isolated (the seed is
+ * the sync identity, not an OAuth token).
+ *
+ * The seed is 128 bits of CSPRNG entropy, returned as hex. BIP39 mnemonic
+ * encoding is a lossless re-encoding of this entropy and can be applied by the
+ * device (or layered on here behind a BIP39 library) without changing the
+ * stored material.
+ */
+class SeedReleaseController extends Controller
+{
+    /**
+     * 128-bit seed = 16 bytes of entropy (BIP39's standard 12-word strength).
+     */
+    private const SEED_BYTES = 16;
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        if (! $request->user() || ! $request->user()->tokenCan('sync')) {
+            return response()->json(['error' => 'insufficient_scope'], 403);
+        }
+
+        $syncSeed = SyncSeed::firstOrCreate(
+            ['user_id' => $request->user()->id],
+            ['seed' => bin2hex(random_bytes(self::SEED_BYTES))],
+        );
+
+        return response()->json([
+            'seed' => $syncSeed->seed,
+            'encoding' => 'hex',
+            'bits' => self::SEED_BYTES * 8,
+        ]);
+    }
+}

--- a/app/Models/SyncSeed.php
+++ b/app/Models/SyncSeed.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * A user's sync-chain seed — the single shared secret behind self-hosted,
+ * client-side-encrypted browser/OS sync (go-sync / Brave Sync v2 compatible).
+ *
+ * The seed is the sync identity: the device derives the signing keypair and the
+ * client-side encryption (Nigori) key from it. aut.hair only gates *release* of
+ * the seed (see SeedReleaseController); it never participates in the sync wire.
+ *
+ * Stored encrypted at rest via the `encrypted` cast (uses APP_KEY). APP_KEY is
+ * therefore part of the trust base — back it up separately from the database.
+ */
+class SyncSeed extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'seed',
+    ];
+
+    protected $casts = [
+        'seed' => 'encrypted',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,6 +6,7 @@ use App\Models\Contracts\CrudContract;
 use App\Models\Contracts\Owner;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -73,6 +74,11 @@ class User extends Authenticatable implements CrudContract, LdapAuthenticatable,
     public function socials(): MorphMany
     {
         return $this->morphMany(Social::class, 'ownable');
+    }
+
+    public function syncSeed(): HasOne
+    {
+        return $this->hasOne(SyncSeed::class);
     }
 
     public function getActivitylogOptions(): LogOptions

--- a/config/openid.php
+++ b/config/openid.php
@@ -15,6 +15,7 @@ return [
             'profile' => 'Information about your profile',
             'email' => 'Information about your email address',
             'address' => 'Information about your address',
+            'sync' => 'Release your sync-chain seed for self-hosted device sync',
             // 'login' => 'See your login information',
         ],
     ],

--- a/database/migrations/2026_06_13_000000_create_sync_seeds_table.php
+++ b/database/migrations/2026_06_13_000000_create_sync_seeds_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('sync_seeds', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(User::class)->constrained()->cascadeOnDelete();
+            // Stored encrypted via the SyncSeed model's `encrypted` cast (APP_KEY).
+            // Holds the user's sync-chain seed material (canonical entropy).
+            $table->text('seed');
+            $table->timestamps();
+
+            // One sync-chain seed per user (shared across all their devices).
+            $table->unique('user_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('sync_seeds');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\MachineInfoController;
+use App\Http\Controllers\SeedReleaseController;
 use App\Http\Controllers\UserinfoController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -21,6 +22,11 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 });
 
 Route::middleware(['auth:api'])->get('userinfo', UserinfoController::class)->name('oidc.userinfo');
+
+// Releases the user's sync-chain seed (creating it on first use). Gated by the
+// `sync` scope. The seed is the identity for self-hosted, client-side-encrypted
+// browser/OS sync; aut.hair gates its release, not the sync wire itself.
+Route::middleware(['auth:api'])->post('sync-seed', SeedReleaseController::class)->name('sync.seed');
 
 Route::middleware([\Laravel\Passport\Http\Middleware\CheckClientCredentials::class])
     ->get('machine-info', MachineInfoController::class)

--- a/tests/Feature/SyncSeedEndpointTest.php
+++ b/tests/Feature/SyncSeedEndpointTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\SyncSeed;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+
+class SyncSeedEndpointTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'passport.public_key' => base_path('tests/Feature/test-public.key'),
+            'passport.private_key' => base_path('tests/Feature/test-private.key'),
+        ]);
+    }
+
+    public function test_sync_seed_requires_sync_scope(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+
+        Passport::actingAs($user, ['openid']); // missing sync
+
+        $response = $this->postJson(route('sync.seed'));
+
+        $response->assertStatus(403);
+        $response->assertJson(['error' => 'insufficient_scope']);
+    }
+
+    public function test_sync_seed_is_created_on_first_call(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+
+        Passport::actingAs($user, ['sync']);
+
+        $response = $this->postJson(route('sync.seed'));
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure(['seed', 'encoding', 'bits']);
+        $response->assertJson(['encoding' => 'hex', 'bits' => 128]);
+
+        // 128 bits = 16 bytes = 32 hex chars.
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{32}$/', $response->json('seed'));
+        $this->assertDatabaseCount('sync_seeds', 1);
+        $this->assertDatabaseHas('sync_seeds', ['user_id' => $user->id]);
+    }
+
+    public function test_sync_seed_is_idempotent_and_stable_per_user(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+
+        Passport::actingAs($user, ['sync']);
+
+        $first = $this->postJson(route('sync.seed'))->json('seed');
+        $second = $this->postJson(route('sync.seed'))->json('seed');
+
+        $this->assertSame($first, $second, 'Repeated calls must return the same seed.');
+        $this->assertDatabaseCount('sync_seeds', 1);
+    }
+
+    public function test_sync_seed_is_encrypted_at_rest(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+
+        Passport::actingAs($user, ['sync']);
+
+        $plain = $this->postJson(route('sync.seed'))->json('seed');
+
+        // Re-reading through the model decrypts and matches what the API returned.
+        $this->assertSame($plain, $user->fresh()->syncSeed->seed);
+        // The raw DB column must NOT contain the plaintext seed (encrypted cast).
+        $this->assertNotSame($plain, $this->rawColumn('sync_seeds', 'seed', $user->id));
+    }
+
+    private function rawColumn(string $table, string $column, int $userId): string
+    {
+        return (string) \Illuminate\Support\Facades\DB::table($table)
+            ->where('user_id', $userId)
+            ->value($column);
+    }
+}


### PR DESCRIPTION
## What

Adds **`POST /api/sync-seed`** — a Passport-protected endpoint (`auth:api`, scope `sync`) that returns the authenticated user's **sync-chain seed**, generating it on first use and storing it **encrypted at rest**.

This is the linchpin for an identity-gated, self-hosted, client-side-encrypted browser/OS sync setup (Brave `go-sync` / Sync v2 compatible). `aut.hair` gates *release* of the seed; the seed — not an OAuth token — is the sync identity, so the **same user yields the same seed on every device** (the "powerwash → sign in → fully-synced slate" model).

## How it fits the repo

Mirrors existing conventions:
- Invokable controller with `tokenCan('sync')` / `403 insufficient_scope` guard — same shape as `UserinfoController`.
- `auth:api` Passport guard in `routes/api.php`.
- New `sync` scope registered in `config/openid.php` (surfaces in `/.well-known/openid-configuration`).
- At-rest encryption via Eloquent's `encrypted` cast (uses `APP_KEY`).

## Changes

| File | Change |
|---|---|
| `app/Http/Controllers/SeedReleaseController.php` | New invokable controller |
| `app/Models/SyncSeed.php` | New model, `seed` => `encrypted`, `belongsTo(User)` |
| `app/Models/User.php` | `syncSeed()` hasOne relation |
| `database/migrations/*_create_sync_seeds_table.php` | `sync_seeds` (one seed per user, unique) |
| `routes/api.php` | `POST sync-seed` (route name `sync.seed`) |
| `config/openid.php` | Register `sync` scope |
| `tests/Feature/SyncSeedEndpointTest.php` | 4 feature tests |

## Behavior

- **Seed material:** 128 bits of CSPRNG entropy, returned as hex (`{ "seed": "<hex>", "encoding": "hex", "bits": 128 }`).
- **Idempotent:** repeated calls return the same seed; one row per user.
- **Encrypted at rest:** the raw DB column is ciphertext.
- BIP39 mnemonic encoding is a *lossless re-encoding* of this entropy and can be layered on device-side (or behind a BIP39 library) without a schema change — kept dependency-free here to avoid touching `composer.lock`.

## Tests

`SyncSeedEndpointTest` (4 tests, 14 assertions) — pass locally on PHP 8.2 / sqlite `:memory:`:
- requires the `sync` scope (403 otherwise),
- creates the seed on first call (correct shape + DB row),
- idempotent / stable per user,
- encrypted at rest (raw column ≠ plaintext, decrypts back via the model).

> Note: I couldn't bring up the full Sail stack locally (private `austinkregel/*` images need a docker login; `selenium/standalone-chrome` has no arm64 manifest). The 12 unrelated suite failures on a fresh checkout are all `Vite manifest not found` (no `npm run build`), not from this change. CI builds assets, so it should be green.

## Seed-lifecycle notes (for review)

- `APP_KEY` is part of the trust base (it encrypts the seed) — back it up separately from the DB.
- Seed **loss = loss of synced state** (it's the encryption key); consider a re-auth-gated "reveal seed" path so users can record it offline.
- **Rotation starts a new sync chain** (old encrypted blobs become undecryptable) — treat as "reset sync," not "re-key in place."

🤖 Generated with [Claude Code](https://claude.com/claude-code)