### PR TITLE
GAIA-compat for openFyde sign-in (self-hosted ChromeOS identity)

### DIFF
--- a/app/Console/Commands/CrosSetup.php
+++ b/app/Console/Commands/CrosSetup.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Laravel\Passport\Client;
+use Laravel\Passport\ClientRepository;
+
+/**
+ * `cros:setup` — provision everything aut.hair needs for openFyde (ChromeOS)
+ * GAIA sign-in:
+ *
+ *   - a CONFIDENTIAL "ChromeOS" Passport client (authorization_code + refresh
+ *     grants, the GAIA scopes from config/gaia.php), tied to a team;
+ *   - the exact env values to wire both sides (this app's .env and the build
+ *     host's openFyde/auth.env).
+ *
+ * The GAIA scopes themselves live in config/openid.php (tokens_can) and are
+ * already registered; this command provisions the client that uses them.
+ *
+ * Idempotent: re-running reports the existing client. The secret is shown only
+ * at creation (Passport hashes it at rest) — use --force to rotate by recreating.
+ */
+class CrosSetup extends Command
+{
+    protected $signature = 'cros:setup
+        {--name=openFyde ChromeOS : OAuth client display name}
+        {--team= : Team id to own the client (default: first team)}
+        {--redirect= : Redirect URI (default: config gaia.redirect_uri)}
+        {--force : Recreate the client if it exists (rotates the secret)}';
+
+    protected $description = 'Provision the aut.hair side of openFyde GAIA sign-in (confidential ChromeOS client)';
+
+    public function handle(ClientRepository $clients): int
+    {
+        $name = (string) $this->option('name');
+        $redirect = (string) ($this->option('redirect') ?: config('gaia.redirect_uri'));
+        $teamId = $this->option('team') ?: DB::table('teams')->orderBy('id')->value('id');
+
+        if (! $teamId) {
+            $this->error('No team found. Create a team in aut.hair first, or pass --team=<id>.');
+
+            return self::FAILURE;
+        }
+
+        $existing = Client::where('name', $name)->where('revoked', false)->first();
+
+        if ($existing && ! $this->option('force')) {
+            $this->warn("Client \"{$name}\" already exists (id {$existing->id}).");
+            $this->line('The secret is only shown at creation; re-run with --force to rotate it.');
+            $this->printEnv($existing->id, '<unchanged — use --force to reveal a new one>', $redirect);
+
+            return self::SUCCESS;
+        }
+
+        if ($existing) {
+            $existing->forceFill(['revoked' => true])->save();
+            $this->warn("Revoked existing client {$existing->id} (--force).");
+        }
+
+        // Mirror ClientController@store: confidential client, then team + grants.
+        $client = $clients->create(null, $name, $redirect, null, false, false, true);
+        $client->team_id = $teamId;
+        $client->user_id = null;
+        $client->save();
+        $client->forceFill([
+            'grant_types' => ['authorization_code', 'refresh_token'],
+            'scopes' => config('gaia.scopes'),
+        ])->save();
+
+        $this->info("Registered confidential ChromeOS client (team {$teamId}).");
+        $this->printEnv($client->id, (string) $client->plainSecret, $redirect);
+
+        return self::SUCCESS;
+    }
+
+    private function printEnv(string $clientId, string $secret, string $redirect): void
+    {
+        $this->newLine();
+        $this->line('# aut.hair — set in .env:');
+        $this->line("GAIA_CHROMEOS_CLIENT_ID={$clientId}");
+        $this->line("GAIA_CHROMEOS_REDIRECT_URI={$redirect}");
+        $this->newLine();
+        $this->line('# build host — set in openFyde/auth.env, then `./build.sh image`:');
+        $this->line("OPENFYDE_OAUTH_CLIENT_ID={$clientId}");
+        $this->line("OPENFYDE_OAUTH_CLIENT_SECRET={$secret}");
+    }
+}

--- a/app/Http/Controllers/Gaia/EmbeddedSetupController.php
+++ b/app/Http/Controllers/Gaia/EmbeddedSetupController.php
@@ -8,25 +8,26 @@ use Illuminate\Support\Facades\Cookie;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Laravel\Passport\Bridge\User as PassportUser;
+use Laravel\Passport\Client;
 use League\OAuth2\Server\AuthorizationServer;
+use League\OAuth2\Server\Exception\OAuthServerException;
 use Nyholm\Psr7\Response as Psr7Response;
 use Nyholm\Psr7\ServerRequest;
 
 /**
  * GAIA sign-in webview page (`GET embedded/setup/v2/chromeos`).
  *
- * Served to the ChromeOS OOBE <webview>. This route is behind web/auth, so an
- * unauthenticated device hits aut.hair's normal login (credentials + 2FA) first
- * and is redirected back here once authenticated — reusing aut.hair's real auth.
+ * Served to the ChromeOS OOBE <webview>. Behind web/auth, so an unauthenticated
+ * device hits aut.hair's normal login (credentials + 2FA) first and is
+ * redirected back once authenticated — reusing aut.hair's real auth.
  *
  * Completion contract (see the fyde-fork repo's docs/gaia-shim-spike.md):
- * authenticator.js (the webview host) completes sign-in when it sees, on the
- * response, the `google-accounts-signin` header (email + obfuscatedid/gaia id +
- * sessionindex) AND a `userInfo`+`closeView` postMessage pair, and when the
- * browser then reads the `oauth_code` cookie. The header parser lowercases the
- * whole value, so we emit a lowercased email; the cookie is the authorization
- * code the browser exchanges at oauth2/v4/token. The cookie is exempt from
- * Laravel cookie encryption (EncryptCookies::$except) so the device reads it raw.
+ * authenticator.js completes sign-in when it sees the `google-accounts-signin`
+ * header + a `userInfo`+`closeView` postMessage pair, and when the browser then
+ * reads the `oauth_code` cookie. The header parser lowercases the whole value,
+ * so we emit a lowercased email; the cookie is the authorization code the
+ * browser exchanges at oauth2/v4/token, and is exempt from cookie encryption
+ * (EncryptCookies::$except) so the device reads it raw.
  */
 class EmbeddedSetupController extends Controller
 {
@@ -39,10 +40,25 @@ class EmbeddedSetupController extends Controller
         $email = strtolower((string) $user->email);
         $gaiaId = (string) $user->getKey();
 
-        // oauth_code cookie: Path=/, HttpOnly, Secure, SameSite=None — required
-        // for the cross-site Set-Cookie the webview's signin partition accepts.
+        try {
+            $authCode = $this->mintAuthCode($user);
+        } catch (OAuthServerException $e) {
+            // A provisioning mistake (client revoked/missing, redirect_uri
+            // mismatch, rejected scope) must NOT 500 the device mid-OOBE. Log it
+            // for the admin and show a clean error page that emits no completion
+            // signals, so the webview surfaces the failure instead of hanging or
+            // crashing.
+            Log::error('gaia: could not mint sign-in code — check `php artisan cros:setup` provisioning (client, redirect_uri, scopes). '.$e->getMessage(), [
+                'client_id' => config('gaia.client_id'),
+                'hint' => $e->getHint(),
+            ]);
+
+            return response()->view('gaia.error', [], 200);
+        }
+
+        // oauth_code cookie: Path=/, HttpOnly, Secure, SameSite=None.
         Cookie::queue(
-            cookie()->make('oauth_code', $this->mintAuthCode($user), 0, '/', null, true, true, false, 'none')
+            cookie()->make('oauth_code', $authCode, 0, '/', null, true, true, false, 'none')
         );
 
         return response()
@@ -57,12 +73,13 @@ class EmbeddedSetupController extends Controller
      * Mint a real Passport authorization code for the confidential ChromeOS
      * client (config gaia.client_id, provisioned by `php artisan cros:setup`),
      * approved on behalf of the signed-in user. Chromium exchanges this code at
-     * oauth2/v4/token (which reuses AccessTokenController@issueToken; that pulls
-     * the team from the client). Team-scoping therefore comes from the client's
-     * team_id — no per-code stamping needed here.
+     * oauth2/v4/token; team-scoping comes from the client's team_id.
+     *
+     * Throws OAuthServerException when the client is misconfigured — handled in
+     * __invoke() so it never reaches the device as a 500.
      *
      * If the client isn't provisioned yet (no gaia.client_id), fall back to an
-     * opaque placeholder + a warning, so the page/contract still works pre-setup.
+     * opaque placeholder + a warning so the page/contract still works pre-setup.
      */
     private function mintAuthCode($user): string
     {
@@ -74,14 +91,17 @@ class EmbeddedSetupController extends Controller
             return Str::random(64);
         }
 
-        // Drive Passport's own authorize flow server-side: validate the request
-        // for the ChromeOS client, approve it for this user, and capture the
-        // issued code from the redirect — a genuine, redeemable Passport code.
+        // Source redirect_uri from the client record itself so it can never
+        // desync from whatever `cros:setup --redirect` registered (config
+        // gaia.redirect_uri is only the default cros:setup uses). A missing
+        // client falls through to validateAuthorizationRequest(), which throws.
+        $redirectUri = optional(Client::find($clientId))->redirect ?: config('gaia.redirect_uri');
+
         $authorizeRequest = (new ServerRequest('GET', rtrim((string) config('app.url'), '/').'/oauth/authorize'))
             ->withQueryParams([
                 'response_type' => 'code',
                 'client_id' => $clientId,
-                'redirect_uri' => config('gaia.redirect_uri'),
+                'redirect_uri' => $redirectUri,
                 'scope' => implode(' ', (array) config('gaia.scopes', [])),
                 'state' => Str::random(40),
                 'nonce' => Str::random(40), // harmless if unused; satisfies OIDC when openid is requested

--- a/app/Http/Controllers/Gaia/EmbeddedSetupController.php
+++ b/app/Http/Controllers/Gaia/EmbeddedSetupController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Controllers\Gaia;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cookie;
+use Illuminate\Support\Str;
+
+/**
+ * GAIA sign-in webview page (`GET embedded/setup/v2/chromeos`).
+ *
+ * Served to the ChromeOS OOBE <webview>. This route is behind web/auth, so an
+ * unauthenticated device hits aut.hair's normal login (credentials + 2FA) first
+ * and is redirected back here once authenticated — reusing aut.hair's real auth
+ * rather than reimplementing it.
+ *
+ * Completion contract (see the fyde-fork repo's docs/gaia-shim-spike.md):
+ * authenticator.js (the webview host) completes sign-in only when it sees, on
+ * the response, the `google-accounts-signin` header (email + obfuscatedid/gaia
+ * id + sessionindex) AND a `userInfo`+`closeView` postMessage pair, and when the
+ * browser later reads the `oauth_code` cookie. The header parser lowercases the
+ * whole value, so we emit a lowercased email; the cookie is the auth code the
+ * browser exchanges at oauth2/v4/token.
+ *
+ * SLICE 2a: this lands the page + the byte-exact header/cookie/postMessage
+ * contract (CI-testable). SLICE 2b replaces mintAuthCode() with a real Passport
+ * authorization code bound to the confidential "ChromeOS" client (+ team), and
+ * validates token redemption + the live webview handshake in a cros vm.
+ */
+class EmbeddedSetupController extends Controller
+{
+    public function __invoke(Request $request)
+    {
+        $user = $request->user(); // guaranteed by the auth middleware
+
+        $email = strtolower((string) $user->email);
+        $gaiaId = (string) $user->getKey();
+
+        // oauth_code cookie: Path=/, HttpOnly, Secure, SameSite=None — required
+        // for the cross-site Set-Cookie the webview's signin partition accepts.
+        Cookie::queue(
+            cookie()->make('oauth_code', $this->mintAuthCode($user), 0, '/', null, true, true, false, 'none')
+        );
+
+        return response()
+            ->view('gaia.embedded-setup', ['services' => []])
+            ->header(
+                'google-accounts-signin',
+                sprintf('email="%s", obfuscatedid="%s", sessionindex=0', $email, $gaiaId)
+            );
+    }
+
+    /**
+     * TODO(slice 2b): mint a REAL Passport authorization code bound to the
+     * confidential "ChromeOS" client (and its team, per the #37 client-team
+     * binding), redeemable at oauth2/v4/token. That depends on the confidential
+     * client existing (separate auth fix) and is validated on-device.
+     *
+     * For now this is an opaque placeholder so the cookie/header/postMessage
+     * contract is exercised and CI-tested end to end on the page side; only the
+     * token-exchange redemption is deferred.
+     */
+    private function mintAuthCode($user): string
+    {
+        return Str::random(64);
+    }
+}

--- a/app/Http/Controllers/Gaia/EmbeddedSetupController.php
+++ b/app/Http/Controllers/Gaia/EmbeddedSetupController.php
@@ -5,31 +5,33 @@ namespace App\Http\Controllers\Gaia;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cookie;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use Laravel\Passport\Bridge\User as PassportUser;
+use League\OAuth2\Server\AuthorizationServer;
+use Nyholm\Psr7\Response as Psr7Response;
+use Nyholm\Psr7\ServerRequest;
 
 /**
  * GAIA sign-in webview page (`GET embedded/setup/v2/chromeos`).
  *
  * Served to the ChromeOS OOBE <webview>. This route is behind web/auth, so an
  * unauthenticated device hits aut.hair's normal login (credentials + 2FA) first
- * and is redirected back here once authenticated — reusing aut.hair's real auth
- * rather than reimplementing it.
+ * and is redirected back here once authenticated — reusing aut.hair's real auth.
  *
  * Completion contract (see the fyde-fork repo's docs/gaia-shim-spike.md):
- * authenticator.js (the webview host) completes sign-in only when it sees, on
- * the response, the `google-accounts-signin` header (email + obfuscatedid/gaia
- * id + sessionindex) AND a `userInfo`+`closeView` postMessage pair, and when the
- * browser later reads the `oauth_code` cookie. The header parser lowercases the
- * whole value, so we emit a lowercased email; the cookie is the auth code the
- * browser exchanges at oauth2/v4/token.
- *
- * SLICE 2a: this lands the page + the byte-exact header/cookie/postMessage
- * contract (CI-testable). SLICE 2b replaces mintAuthCode() with a real Passport
- * authorization code bound to the confidential "ChromeOS" client (+ team), and
- * validates token redemption + the live webview handshake in a cros vm.
+ * authenticator.js (the webview host) completes sign-in when it sees, on the
+ * response, the `google-accounts-signin` header (email + obfuscatedid/gaia id +
+ * sessionindex) AND a `userInfo`+`closeView` postMessage pair, and when the
+ * browser then reads the `oauth_code` cookie. The header parser lowercases the
+ * whole value, so we emit a lowercased email; the cookie is the authorization
+ * code the browser exchanges at oauth2/v4/token. The cookie is exempt from
+ * Laravel cookie encryption (EncryptCookies::$except) so the device reads it raw.
  */
 class EmbeddedSetupController extends Controller
 {
+    public function __construct(private AuthorizationServer $server) {}
+
     public function __invoke(Request $request)
     {
         $user = $request->user(); // guaranteed by the auth middleware
@@ -52,17 +54,47 @@ class EmbeddedSetupController extends Controller
     }
 
     /**
-     * TODO(slice 2b): mint a REAL Passport authorization code bound to the
-     * confidential "ChromeOS" client (and its team, per the #37 client-team
-     * binding), redeemable at oauth2/v4/token. That depends on the confidential
-     * client existing (separate auth fix) and is validated on-device.
+     * Mint a real Passport authorization code for the confidential ChromeOS
+     * client (config gaia.client_id, provisioned by `php artisan cros:setup`),
+     * approved on behalf of the signed-in user. Chromium exchanges this code at
+     * oauth2/v4/token (which reuses AccessTokenController@issueToken; that pulls
+     * the team from the client). Team-scoping therefore comes from the client's
+     * team_id — no per-code stamping needed here.
      *
-     * For now this is an opaque placeholder so the cookie/header/postMessage
-     * contract is exercised and CI-tested end to end on the page side; only the
-     * token-exchange redemption is deferred.
+     * If the client isn't provisioned yet (no gaia.client_id), fall back to an
+     * opaque placeholder + a warning, so the page/contract still works pre-setup.
      */
     private function mintAuthCode($user): string
     {
-        return Str::random(64);
+        $clientId = config('gaia.client_id');
+
+        if (empty($clientId)) {
+            Log::warning('gaia: GAIA_CHROMEOS_CLIENT_ID is not set; emitting a placeholder oauth_code. Run `php artisan cros:setup`.');
+
+            return Str::random(64);
+        }
+
+        // Drive Passport's own authorize flow server-side: validate the request
+        // for the ChromeOS client, approve it for this user, and capture the
+        // issued code from the redirect — a genuine, redeemable Passport code.
+        $authorizeRequest = (new ServerRequest('GET', rtrim((string) config('app.url'), '/').'/oauth/authorize'))
+            ->withQueryParams([
+                'response_type' => 'code',
+                'client_id' => $clientId,
+                'redirect_uri' => config('gaia.redirect_uri'),
+                'scope' => implode(' ', (array) config('gaia.scopes', [])),
+                'state' => Str::random(40),
+                'nonce' => Str::random(40), // harmless if unused; satisfies OIDC when openid is requested
+            ]);
+
+        $authRequest = $this->server->validateAuthorizationRequest($authorizeRequest);
+        $authRequest->setUser(new PassportUser($user->getAuthIdentifier()));
+        $authRequest->setAuthorizationApproved(true);
+
+        $response = $this->server->completeAuthorizationRequest($authRequest, new Psr7Response);
+
+        parse_str((string) parse_url($response->getHeaderLine('Location'), PHP_URL_QUERY), $params);
+
+        return (string) ($params['code'] ?? '');
     }
 }

--- a/app/Http/Controllers/Gaia/UserinfoController.php
+++ b/app/Http/Controllers/Gaia/UserinfoController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\Gaia;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * GAIA UserInfo (`oauth2/v1/userinfo`) for openFyde sign-in.
+ *
+ * Chromium calls this with an access token to resolve the signed-in identity.
+ * Returns the GAIA shape Chromium parses: `id` (the stable gaia id, which must
+ * match the `obfuscatedid` emitted in the `google-accounts-signin` header at
+ * sign-in), `email`, and `verified_email`.
+ *
+ * We deliberately OMIT `hostedDomain`: its absence makes Chromium treat the
+ * account as a consumer account and skip enterprise device-management
+ * enrollment (see the fyde-fork repo's docs/gaia-shim-spike.md). Add it back
+ * only if managed enrollment is wanted.
+ *
+ * Mirrors the invokable, `auth:api`-gated style of UserinfoController /
+ * SeedReleaseController.
+ */
+class UserinfoController extends Controller
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        if (! $user) {
+            return response()->json(['error' => 'invalid_token'], 401);
+        }
+
+        return response()->json([
+            'id' => (string) $user->getKey(),
+            'email' => $user->email,
+            'verified_email' => (bool) $user->email_verified_at,
+        ]);
+    }
+}

--- a/app/Http/Middleware/EncryptCookies.php
+++ b/app/Http/Middleware/EncryptCookies.php
@@ -12,6 +12,9 @@ class EncryptCookies extends Middleware
      * @var array<int, string>
      */
     protected $except = [
-        //
+        // openFyde/ChromeOS reads this cookie raw (it's the GAIA oauth_code the
+        // device exchanges at oauth2/v4/token), so it must NOT be Laravel-
+        // encrypted. See app/Http/Controllers/Gaia/EmbeddedSetupController.
+        'oauth_code',
     ];
 }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -44,6 +44,12 @@ class RouteServiceProvider extends ServiceProvider
                 Route::prefix('oauth')
                     ->group(base_path('routes/passport.php'));
             });
+
+            // GAIA-compat (openFyde / ChromeOS): root-relative endpoints, no
+            // prefix (Chromium calls e.g. /oauth2/v4/token, /oauth2/v1/userinfo).
+            // Per-route middleware is set in the file.
+            Route::as('gaia.')
+                ->group(base_path('routes/gaia.php'));
         });
     }
 }

--- a/app/Repositories/GaiaScopeRepository.php
+++ b/app/Repositories/GaiaScopeRepository.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories;
+
+use OpenIDConnect\Entities\ScopeEntity;
+use OpenIDConnect\Repositories\ScopeRepository as BaseScopeRepository;
+
+/**
+ * Scope repository that recognizes the GAIA scopes openFyde/ChromeOS requests
+ * (e.g. https://www.googleapis.com/auth/chromesync, .../OAuthLogin) on top of
+ * the standard OIDC scopes.
+ *
+ * The vendor ScopeRepository hardcodes only {openid, profile, email, phone,
+ * address} and ignores config, so any GAIA scope is rejected as "invalid scope"
+ * at grant time — which would break both our sign-in code mint and Chromium's
+ * own chromesync token requests. We instead accept anything registered in
+ * config('openid.passport.tokens_can'), which is where the GAIA scopes are
+ * declared (see config/openid.php). Wired in via config('openid.repositories.scope').
+ */
+class GaiaScopeRepository extends BaseScopeRepository
+{
+    public function getScopeEntityByIdentifier($identifier)
+    {
+        $allowed = array_merge(
+            ['openid', 'profile', 'email', 'phone', 'address'],
+            array_keys((array) config('openid.passport.tokens_can', []))
+        );
+
+        if (! in_array($identifier, $allowed, true)) {
+            return null;
+        }
+
+        $scope = new ScopeEntity();
+        $scope->setIdentifier($identifier);
+
+        return $scope;
+    }
+}

--- a/config/gaia.php
+++ b/config/gaia.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | openFyde (ChromeOS) GAIA-compat config
+    |--------------------------------------------------------------------------
+    |
+    | The confidential "ChromeOS" Passport client openFyde signs in against, and
+    | the scopes its sign-in token carries. Run `php artisan cros:setup` to
+    | provision the client, then set GAIA_CHROMEOS_CLIENT_ID here (and the same
+    | id/secret in openFyde/auth.env on the build host). See the fyde-fork repo's
+    | docs/gaia-shim-spike.md.
+    */
+
+    // The confidential ChromeOS client id (from `cros:setup`). The sign-in page
+    // mints authorization codes for this client; oauth2/v4/token redeems them.
+    'client_id' => env('GAIA_CHROMEOS_CLIENT_ID'),
+
+    // Registered redirect_uri for that client. The device's code exchange aligns
+    // with this; the exact value Chromium uses is finalized during on-device
+    // validation.
+    'redirect_uri' => env('GAIA_CHROMEOS_REDIRECT_URI', 'https://chromeos.localhost/oauth2/callback'),
+
+    // Scopes minted for the sign-in token — the literal GAIA scope strings
+    // Chromium requests. Kept in sync with config/openid.php `tokens_can`.
+    'scopes' => [
+        'openid',
+        'email',
+        'https://www.google.com/accounts/OAuthLogin',
+        'https://www.googleapis.com/auth/chromesync',
+        'https://www.googleapis.com/auth/userinfo.email',
+        'https://www.googleapis.com/auth/userinfo.profile',
+    ],
+];

--- a/config/openid.php
+++ b/config/openid.php
@@ -17,6 +17,18 @@ return [
             'address' => 'Information about your address',
             'sync' => 'Release your sync-chain seed for self-hosted device sync',
             // 'login' => 'See your login information',
+
+            // ChromeOS / GAIA-compat scopes. openFyde's Chromium requests these
+            // literal Google scope strings verbatim during sign-in, Chrome Sync,
+            // and device management (it speaks GAIA, repointed at us via
+            // --fydeos-gaia-url/--fydeos-apis-url). Registered so Passport will
+            // mint tokens for them. See the fyde-fork repo's docs/gaia-shim-spike.md.
+            'https://www.google.com/accounts/OAuthLogin' => 'Sign in to your openFyde device',
+            'https://www.googleapis.com/auth/chromesync' => 'Sync your openFyde browser and OS state',
+            'https://www.googleapis.com/auth/userinfo.email' => 'See your email address (openFyde)',
+            'https://www.googleapis.com/auth/userinfo.profile' => 'See your basic profile info (openFyde)',
+            // Deferred (enterprise enrollment only; consumer sign-in skips DM):
+            'https://www.googleapis.com/auth/chromeosdevicemanagement' => 'Enroll this device in management',
         ],
     ],
 

--- a/config/openid.php
+++ b/config/openid.php
@@ -52,7 +52,10 @@ return [
      */
     'repositories' => [
         'identity' => \OpenIDConnect\Repositories\IdentityRepository::class,
-        'scope' => \OpenIDConnect\Repositories\ScopeRepository::class,
+        // GaiaScopeRepository extends the OIDC one to also accept the GAIA
+        // scopes (from tokens_can above) — the vendor repo hardcodes only the
+        // 5 OIDC scopes and would reject chromesync/OAuthLogin/etc.
+        'scope' => \App\Repositories\GaiaScopeRepository::class,
     ],
 
     /**

--- a/resources/views/gaia/embedded-setup.blade.php
+++ b/resources/views/gaia/embedded-setup.blade.php
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Sign in</title>
+</head>
+<body>
+    <p>Signing you in…</p>
+    <script>
+    // openFyde sign-in page, served at GET embedded/setup/v2/chromeos inside the
+    // ChromeOS OOBE <webview>.
+    //
+    // By the time this page renders, the user is already authenticated against
+    // aut.hair (this route is behind web/auth — unauthed users were sent to
+    // aut.hair's normal login first). The two completion signals the host (
+    // authenticator.js) reads from the response — the `google-accounts-signin`
+    // header and the `oauth_code` cookie — are set server-side on THIS document
+    // response. All this page must do is, after the host's handshake, emit
+    // `userInfo` (services) then `closeView` (order enforced by the host).
+    (function () {
+        var hostWin = null, hostOrigin = null;
+        // [] = a regular/adult account; child accounts add flags like 'uca'.
+        var services = @json($services ?? []);
+
+        function post(msg) {
+            if (hostWin) { hostWin.postMessage(msg, hostOrigin); }
+        }
+
+        window.addEventListener('message', function (e) {
+            // The host (chrome://oobe) posts {method:'handshake'} first; capture
+            // its window + origin, then reply only there.
+            if (e && e.data && e.data.method === 'handshake') {
+                hostWin = e.source;
+                hostOrigin = e.origin;
+                // userInfo MUST precede closeView (authenticator.js logs an error
+                // and won't complete if closeView arrives first).
+                post({ method: 'userInfo', services: services });
+                post({ method: 'closeView' });
+            }
+        });
+    })();
+    </script>
+</body>
+</html>

--- a/resources/views/gaia/error.blade.php
+++ b/resources/views/gaia/error.blade.php
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Sign-in unavailable</title>
+</head>
+<body>
+    {{-- Deliberately emits NO completion postMessages: the OOBE webview shows
+         this page instead of completing sign-in with a bad code. The cause
+         (a provisioning mistake) is logged server-side for the admin. --}}
+    <h1>Sign-in is temporarily unavailable</h1>
+    <p>This device can't sign in right now because of a server configuration
+       issue. Please contact your administrator.</p>
+</body>
+</html>

--- a/routes/gaia.php
+++ b/routes/gaia.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Http\Controllers\AccessTokenController;
+use App\Http\Controllers\Gaia\UserinfoController;
+use Illuminate\Support\Facades\Route;
+
+/*
+|--------------------------------------------------------------------------
+| GAIA-compat routes (openFyde / ChromeOS sign-in)
+|--------------------------------------------------------------------------
+|
+| openFyde's Chromium speaks Google's GAIA protocol, repointed at aut.hair via
+| --fydeos-gaia-url / --fydeos-apis-url. These root-relative endpoints mirror
+| the GAIA endpoints Chromium calls; most are thin adapters over aut.hair's
+| existing Passport/OIDC machinery. Registered with NO prefix in
+| RouteServiceProvider (GAIA paths are root-relative). See the fyde-fork repo's
+| docs/gaia-shim-spike.md for the full surface.
+|
+| This file is the token half (device-independent). The sign-in webview page
+| (embedded/setup/v2/chromeos) lands in a later slice.
+*/
+
+// Token endpoint (apis origin) — authorization_code and refresh_token grants.
+// Reuses aut.hair's customized Passport token controller unchanged: Chromium
+// POSTs grant_type/code/client_id/client_secret/scope like any OAuth2 client,
+// and issueToken already handles client_secret_basic/post.
+Route::post('oauth2/v4/token', [AccessTokenController::class, 'issueToken'])
+    ->name('token')
+    ->middleware('throttle');
+
+// UserInfo (apis origin) — the GAIA shape Chromium parses: {id, email,
+// verified_email}. `id` is the stable gaia id (must match the obfuscatedid
+// emitted in the google-accounts-signin header at sign-in). We deliberately
+// OMIT `hostedDomain` so Chromium treats this as a consumer account and skips
+// enterprise device-management enrollment.
+Route::middleware('auth:api')
+    ->get('oauth2/v1/userinfo', UserinfoController::class)
+    ->name('userinfo');

--- a/routes/gaia.php
+++ b/routes/gaia.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\AccessTokenController;
+use App\Http\Controllers\Gaia\EmbeddedSetupController;
 use App\Http\Controllers\Gaia\UserinfoController;
 use Illuminate\Support\Facades\Route;
 
@@ -16,8 +17,9 @@ use Illuminate\Support\Facades\Route;
 | RouteServiceProvider (GAIA paths are root-relative). See the fyde-fork repo's
 | docs/gaia-shim-spike.md for the full surface.
 |
-| This file is the token half (device-independent). The sign-in webview page
-| (embedded/setup/v2/chromeos) lands in a later slice.
+| Includes the token endpoints and the sign-in webview page
+| (embedded/setup/v2/chromeos). Token redemption with a real Passport auth code
+| is slice 2b.
 */
 
 // Token endpoint (apis origin) — authorization_code and refresh_token grants.
@@ -36,3 +38,11 @@ Route::post('oauth2/v4/token', [AccessTokenController::class, 'issueToken'])
 Route::middleware('auth:api')
     ->get('oauth2/v1/userinfo', UserinfoController::class)
     ->name('userinfo');
+
+// Sign-in webview page (GAIA origin) — served to the OOBE <webview>. Behind
+// web/auth: an unauthenticated device hits aut.hair's normal login (creds +
+// 2FA) first, then returns here. The google-accounts-signin header + oauth_code
+// cookie ride on this response; the page posts userInfo -> closeView.
+Route::middleware(['web', 'auth'])
+    ->get('embedded/setup/v2/chromeos', EmbeddedSetupController::class)
+    ->name('embedded-setup');

--- a/tests/Feature/CrosSetupCommandTest.php
+++ b/tests/Feature/CrosSetupCommandTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Client;
+use Tests\TestCase;
+
+/**
+ * `cros:setup` — provisions the confidential ChromeOS OAuth client for openFyde
+ * GAIA sign-in. (Slice 2b-i.)
+ */
+class CrosSetupCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_creates_a_confidential_chromeos_client_for_the_team(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $teamId = $user->currentTeam->id;
+
+        $this->artisan('cros:setup', ['--team' => $teamId])->assertSuccessful();
+
+        $client = Client::where('name', 'openFyde ChromeOS')->first();
+
+        $this->assertNotNull($client, 'cros:setup must create the ChromeOS client');
+        $this->assertEquals($teamId, $client->team_id);
+        $this->assertTrue($client->confidential(), 'client must be confidential (have a secret)');
+        $this->assertContains('authorization_code', $client->grant_types);
+        $this->assertContains('refresh_token', $client->grant_types);
+        $this->assertContains('https://www.googleapis.com/auth/chromesync', $client->scopes);
+    }
+
+    public function test_it_is_idempotent_without_force(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $teamId = $user->currentTeam->id;
+
+        $this->artisan('cros:setup', ['--team' => $teamId])->assertSuccessful();
+        $this->artisan('cros:setup', ['--team' => $teamId])->assertSuccessful();
+
+        $this->assertEquals(
+            1,
+            Client::where('name', 'openFyde ChromeOS')->where('revoked', false)->count(),
+            're-running without --force must not create a second client'
+        );
+    }
+
+    public function test_force_rotates_the_client(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $teamId = $user->currentTeam->id;
+
+        $this->artisan('cros:setup', ['--team' => $teamId])->assertSuccessful();
+        $first = Client::where('name', 'openFyde ChromeOS')->where('revoked', false)->first();
+
+        $this->artisan('cros:setup', ['--team' => $teamId, '--force' => true])->assertSuccessful();
+        $second = Client::where('name', 'openFyde ChromeOS')->where('revoked', false)->first();
+
+        $this->assertNotEquals($first->id, $second->id, '--force must create a fresh client');
+        $this->assertTrue(Client::find($first->id)->revoked, 'the old client must be revoked');
+    }
+
+    public function test_it_fails_without_a_team(): void
+    {
+        // No teams exist (RefreshDatabase, no seeding) -> the command should error.
+        $this->artisan('cros:setup')->assertFailed();
+    }
+}

--- a/tests/Feature/GaiaEmbeddedSetupTest.php
+++ b/tests/Feature/GaiaEmbeddedSetupTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * GAIA sign-in webview page (embedded/setup/v2/chromeos) — slice 2a.
+ *
+ * Covers the byte-exact completion contract the OOBE webview host reads:
+ * the `google-accounts-signin` header, the `oauth_code` cookie, and the
+ * postMessage wiring. Session-authenticated (web guard), since the device
+ * authenticates against aut.hair's normal login before reaching this page.
+ */
+class GaiaEmbeddedSetupTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'passport.public_key' => base_path('tests/Feature/test-public.key'),
+            'passport.private_key' => base_path('tests/Feature/test-private.key'),
+        ]);
+    }
+
+    public function test_unauthenticated_device_is_redirected_to_login(): void
+    {
+        // No session => aut.hair's real login runs first (creds + 2FA), then the
+        // device is sent back here.
+        $this->get(route('gaia.embedded-setup'))->assertRedirect();
+    }
+
+    public function test_authenticated_page_emits_the_signin_contract(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'User@AUT.hair',          // mixed case on purpose
+            'email_verified_at' => now(),
+        ]);
+
+        $response = $this->actingAs($user)->get(route('gaia.embedded-setup'));
+
+        $response->assertStatus(200);
+
+        // google-accounts-signin header: email + obfuscatedid + sessionindex.
+        // The host lowercases the whole value, so we must emit it lowercase.
+        $header = $response->headers->get('google-accounts-signin');
+        $this->assertNotNull($header, 'google-accounts-signin header must be present');
+        $this->assertStringContainsString('email="user@aut.hair"', $header);
+        $this->assertStringContainsString('obfuscatedid="'.$user->id.'"', $header);
+        $this->assertStringContainsString('sessionindex=0', $header);
+
+        // oauth_code cookie (the auth code the browser exchanges later).
+        $response->assertCookie('oauth_code');
+
+        // The page wires the handshake -> userInfo -> closeView completion.
+        $response->assertSee('handshake', false);
+        $response->assertSee('userInfo', false);
+        $response->assertSee('closeView', false);
+    }
+
+    public function test_oauth_code_cookie_is_not_empty(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+
+        $response = $this->actingAs($user)->get(route('gaia.embedded-setup'));
+
+        $value = collect($response->headers->getCookies())
+            ->first(fn ($c) => $c->getName() === 'oauth_code')?->getValue();
+
+        $this->assertNotEmpty($value, 'oauth_code cookie must carry a non-empty value');
+    }
+}

--- a/tests/Feature/GaiaEmbeddedSetupTest.php
+++ b/tests/Feature/GaiaEmbeddedSetupTest.php
@@ -63,6 +63,23 @@ class GaiaEmbeddedSetupTest extends TestCase
         $response->assertSee('closeView', false);
     }
 
+    public function test_misconfigured_client_renders_error_page_not_500(): void
+    {
+        // A provisioning mistake (here: gaia.client_id points at a client that
+        // doesn't exist) must surface as a clean error page, not a 500 mid-OOBE.
+        config(['gaia.client_id' => 'does-not-exist']);
+
+        $user = User::factory()->create(['email_verified_at' => now()]);
+
+        $response = $this->actingAs($user)->get(route('gaia.embedded-setup'));
+
+        $response->assertStatus(200);
+        $response->assertSee('Sign-in is temporarily unavailable', false);
+        // It must NOT pretend to complete: no completion wiring, no auth cookie.
+        $response->assertDontSee('closeView', false);
+        $response->assertCookieMissing('oauth_code');
+    }
+
     public function test_oauth_code_cookie_is_not_empty(): void
     {
         $user = User::factory()->create(['email_verified_at' => now()]);

--- a/tests/Feature/GaiaSignInFlowTest.php
+++ b/tests/Feature/GaiaSignInFlowTest.php
@@ -71,5 +71,18 @@ class GaiaSignInFlowTest extends TestCase
 
         $token->assertStatus(200);
         $token->assertJsonStructure(['token_type', 'expires_in', 'access_token', 'refresh_token']);
+
+        // The redeemed token must carry a GAIA scope — locks in the
+        // GaiaScopeRepository -> finalizeScopes propagation so a refactor can't
+        // silently drop it (which would break Chrome Sync).
+        $claims = json_decode(
+            base64_decode(strtr(explode('.', $token->json('access_token'))[1], '-_', '+/')) ?: '[]',
+            true
+        );
+        $this->assertContains(
+            'https://www.googleapis.com/auth/chromesync',
+            $claims['scopes'] ?? [],
+            'access token must carry the chromesync scope'
+        );
     }
 }

--- a/tests/Feature/GaiaSignInFlowTest.php
+++ b/tests/Feature/GaiaSignInFlowTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\ClientRepository;
+use Tests\TestCase;
+
+/**
+ * End-to-end GAIA sign-in (server side) — slice 2b-ii.
+ *
+ * Proves the whole chain CI can exercise: the sign-in page mints a real Passport
+ * authorization code (cookie) for the confidential ChromeOS client, and the GAIA
+ * token endpoint (oauth2/v4/token) redeems it for tokens. The only piece left
+ * for on-device validation is the webview postMessage handshake itself.
+ */
+class GaiaSignInFlowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'passport.public_key' => base_path('tests/Feature/test-public.key'),
+            'passport.private_key' => base_path('tests/Feature/test-private.key'),
+        ]);
+    }
+
+    public function test_sign_in_page_mints_a_code_that_the_token_endpoint_redeems(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create([
+            'email' => 'owner@aut.hair',
+            'email_verified_at' => now(),
+        ]);
+
+        // Provision the confidential ChromeOS client the way cros:setup does,
+        // but inline so we keep the plain secret for the exchange.
+        $clients = app(ClientRepository::class);
+        $client = $clients->create(null, 'openFyde ChromeOS', config('gaia.redirect_uri'), null, false, false, true);
+        $client->team_id = $user->currentTeam->id;
+        $client->user_id = null;
+        $client->save();
+        $client->forceFill([
+            'grant_types' => ['authorization_code', 'refresh_token'],
+            'scopes' => config('gaia.scopes'),
+        ])->save();
+        $plainSecret = $client->plainSecret;
+
+        config(['gaia.client_id' => $client->id]);
+
+        // 1. The webview loads the sign-in page (authenticated session) and gets
+        //    a raw (un-encrypted) oauth_code cookie.
+        $page = $this->actingAs($user)->get(route('gaia.embedded-setup'));
+        $page->assertStatus(200);
+
+        $code = collect($page->headers->getCookies())
+            ->first(fn ($c) => $c->getName() === 'oauth_code')?->getValue();
+        $this->assertNotEmpty($code, 'sign-in page must set a non-empty oauth_code cookie');
+
+        // 2. The device exchanges the code at the GAIA token endpoint.
+        $token = $this->post('/oauth2/v4/token', [
+            'grant_type' => 'authorization_code',
+            'code' => $code,
+            'client_id' => $client->id,
+            'client_secret' => $plainSecret,
+            'redirect_uri' => config('gaia.redirect_uri'),
+        ]);
+
+        $token->assertStatus(200);
+        $token->assertJsonStructure(['token_type', 'expires_in', 'access_token', 'refresh_token']);
+    }
+}

--- a/tests/Feature/GaiaUserinfoTest.php
+++ b/tests/Feature/GaiaUserinfoTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+
+/**
+ * GAIA UserInfo endpoint (oauth2/v1/userinfo) — the identity Chromium reads
+ * during openFyde sign-in. Mirrors SyncSeedEndpointTest's conventions.
+ */
+class GaiaUserinfoTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'passport.public_key' => base_path('tests/Feature/test-public.key'),
+            'passport.private_key' => base_path('tests/Feature/test-private.key'),
+        ]);
+    }
+
+    public function test_userinfo_requires_a_valid_token(): void
+    {
+        $this->getJson(route('gaia.userinfo'))->assertStatus(401);
+    }
+
+    public function test_userinfo_returns_the_gaia_shape(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'user@aut.hair',
+            'email_verified_at' => now(),
+        ]);
+
+        // Chromium presents a token with the userinfo.email scope.
+        Passport::actingAs($user, ['https://www.googleapis.com/auth/userinfo.email']);
+
+        $response = $this->getJson(route('gaia.userinfo'));
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'id' => (string) $user->id,
+            'email' => 'user@aut.hair',
+            'verified_email' => true,
+        ]);
+    }
+
+    public function test_userinfo_omits_hosted_domain_so_consumer_skips_dm(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+
+        Passport::actingAs($user, ['openid']);
+
+        $response = $this->getJson(route('gaia.userinfo'));
+
+        $response->assertStatus(200);
+        // No hostedDomain => Chromium treats this as a consumer account and does
+        // NOT attempt enterprise device-management enrollment.
+        $response->assertJsonMissingPath('hostedDomain');
+    }
+
+    public function test_unverified_email_is_reported_as_such(): void
+    {
+        $user = User::factory()->unverified()->create();
+
+        Passport::actingAs($user, ['https://www.googleapis.com/auth/userinfo.email']);
+
+        $this->getJson(route('gaia.userinfo'))
+            ->assertStatus(200)
+            ->assertJson(['verified_email' => false]);
+    }
+}


### PR DESCRIPTION
## GAIA-compat for openFyde sign-in (self-hosted ChromeOS identity)

Lets openFyde (ChromeOS) devices sign in against **aut.hair** instead of Google. openFyde's Chromium speaks Google's **GAIA** protocol, repointed at us via `--fydeos-gaia-url`/`--fydeos-apis-url` (Chromium stays unmodified). This PR is the complete **server side**; the remaining step is on-device validation of the webview handshake (a `cros vm`).

### What's here
- **Scopes + `GaiaScopeRepository`** — register + accept the GAIA scope strings at grant time (the vendor OIDC repo hardcoded only the 5 OIDC scopes).
- **`oauth2/v4/token`** — reuses the existing `AccessTokenController@issueToken` unchanged.
- **`oauth2/v1/userinfo`** — `Gaia\\UserinfoController`, GAIA shape `{id,email,verified_email}`, omits `hostedDomain` so consumer sign-in skips enterprise DM.
- **`embedded/setup/v2/chromeos`** — sign-in webview page. Behind web/auth (device hits aut.hair's real login first). Emits `google-accounts-signin` header + raw `oauth_code` cookie (exempt from cookie encryption) + `userInfo`→`closeView`; mints a **real Passport authorization code** for the confidential ChromeOS client.
- **`php artisan cros:setup`** — provisions the confidential ChromeOS client (+ scopes, team) and prints the env block for aut.hair and the build host.

## How to test

**Automated (what CI runs):**
```bash
bin/sail test --filter='Gaia|CrosSetup'
# GaiaUserinfoTest, GaiaEmbeddedSetupTest, CrosSetupCommandTest,
# GaiaSignInFlowTest (end-to-end: page -> oauth_code cookie -> token redemption)
```

**Manual server-side walkthrough:**
1. `bin/sail artisan cros:setup` → note the printed `GAIA_CHROMEOS_CLIENT_ID` + secret; set `GAIA_CHROMEOS_CLIENT_ID` in `.env`.
2. `bin/sail artisan route:list --path='oauth2|embedded'` → confirm `oauth2/v4/token`, `oauth2/v1/userinfo`, `embedded/setup/v2/chromeos`.
3. Log into aut.hair in a browser, visit `/embedded/setup/v2/chromeos` → 200 with the `google-accounts-signin` response header + an `oauth_code` cookie (check devtools/Network).
4. Exchange it: `curl -s -X POST <host>/oauth2/v4/token -d grant_type=authorization_code -d code=<cookie> -d client_id=<id> -d client_secret=<secret> -d redirect_uri=<GAIA_CHROMEOS_REDIRECT_URI>` → JSON with `access_token`/`refresh_token`.

**On-device (not coverable in CI):** build openFyde with the client creds in `openfyde/auth.env` + `--fydeos-gaia-url` at this host, boot in a `cros vm`, confirm OOBE completes the webview handshake.

### Not in this PR (by design)
- On-device webview handshake (validated in a `cros vm`).
- DM/policy server (deferred; consumer sign-in skips it).
- The satellite GAIA endpoints (`ListAccounts`, `oauth/multilogin`, `tokeninfo`, `revoke`, `GetCheckConnectionInfo`) — added only if on-device testing shows the session needs them.
- go-sync seed-token proxy (lives in the fyde-fork `sync/` stack).

Background: the fyde-fork repo's `docs/gaia-shim-spike.md` + decision `D7`.