### PR TITLE
Fix OAuth client secret display, machine tokens, and team grants

### DIFF
--- a/app/Actions/Jetstream/InviteTeamToOAuthClient.php
+++ b/app/Actions/Jetstream/InviteTeamToOAuthClient.php
@@ -18,12 +18,28 @@ class InviteTeamToOAuthClient
 
         $this->validate($invitingTeam, $invitedTeam, $client, $role);
 
-        $invitingTeam->invitedTeams()->syncWithoutDetaching([
-            $invitedTeam->id => [
-                'oauth_client_id' => $client->id,
+        // Each invitation is unique per (inviting team, invited team, client).
+        // A belongsToMany sync keys only on invited_team_id, so it would overwrite
+        // an existing grant when the same team is invited to a second client.
+        $keys = [
+            'inviting_team_id' => $invitingTeam->id,
+            'invited_team_id' => $invitedTeam->id,
+            'oauth_client_id' => $client->id,
+        ];
+
+        $existing = DB::table('oauth_client_team_invitations')->where($keys)->first();
+
+        if ($existing) {
+            DB::table('oauth_client_team_invitations')
+                ->where('id', $existing->id)
+                ->update(['role' => $role, 'updated_at' => now()]);
+        } else {
+            DB::table('oauth_client_team_invitations')->insert($keys + [
                 'role' => $role,
-            ],
-        ]);
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
     }
 
     protected function validate(Team $invitingTeam, Team $invitedTeam, Client $client, ?string $role): void

--- a/app/Http/Controllers/MachineTokenController.php
+++ b/app/Http/Controllers/MachineTokenController.php
@@ -28,7 +28,7 @@ class MachineTokenController extends Controller
         $user = $request->user();
 
         $clients = Client::query()
-            ->where('user_id', $user->id)
+            ->whereIn('team_id', $user->allTeams()->pluck('id'))
             ->where('revoked', false)
             ->get()
             ->filter(fn (Client $client) => $client->hasGrantType('client_credentials') && $client->confidential())
@@ -67,7 +67,7 @@ class MachineTokenController extends Controller
 
         $client = Client::query()
             ->where('id', $validated['client_id'])
-            ->where('user_id', $request->user()->id)
+            ->whereIn('team_id', $request->user()->allTeams()->pluck('id'))
             ->where('revoked', false)
             ->first();
 
@@ -122,7 +122,7 @@ class MachineTokenController extends Controller
     {
         $client = Client::query()
             ->where('id', $clientId)
-            ->where('user_id', $request->user()->id)
+            ->whereIn('team_id', $request->user()->allTeams()->pluck('id'))
             ->where('revoked', false)
             ->first();
 
@@ -171,7 +171,7 @@ class MachineTokenController extends Controller
 
         /** @var Client|null $client */
         $client = Client::find($token->client_id);
-        if (! $client || (string) $client->user_id !== (string) $request->user()->id) {
+        if (! $client || ! $request->user()->allTeams()->pluck('id')->contains($client->team_id)) {
             return response()->json(['error' => 'invalid_client'], 404);
         }
 

--- a/app/Http/Controllers/OAuth/ClientController.php
+++ b/app/Http/Controllers/OAuth/ClientController.php
@@ -59,7 +59,15 @@ class ClientController extends Controller
             'scopes' => $request->input('scopes', []),
         ])->save();
 
-        return $client->fresh();
+        $fresh = $client->fresh();
+
+        // Passport hides the `secret` column. Surface it once on creation so the
+        // user can store a confidential client's secret (it is shown only here).
+        if (! empty($fresh->secret)) {
+            $fresh->makeVisible('secret');
+        }
+
+        return $fresh;
     }
 
     public function update(Request $request, $clientId)

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -53,16 +53,6 @@ class Team extends JetstreamTeam implements CrudContract, Owner
         return $this->hasMany(Client::class, 'team_id');
     }
 
-    public function invitedTeams(): BelongsToMany
-    {
-        return $this->belongsToMany(
-            Team::class,
-            'oauth_client_team_invitations',
-            'inviting_team_id',
-            'invited_team_id'
-        )->withPivot(['oauth_client_id', 'role'])->withTimestamps();
-    }
-
     public function invitingTeams(): BelongsToMany
     {
         return $this->belongsToMany(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     extra_hosts:
       - 'host.docker.internal:host-gateway'
     ports:
-      - '${APP_PORT:-80}:80'
+      - '${APP_PORT:-80}:8000'
     environment:
       WWWUSER: '${WWWUSER}'
       LARAVEL_SAIL: 1
@@ -64,15 +64,13 @@ services:
       - redis
       - selenium
   mysql:
-    image: 'mysql/mysql-server:8.0'
+    image: 'mysql:8.0'
     ports:
       - '${FORWARD_DB_PORT:-3306}:3306'
     environment:
       MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
       MYSQL_ROOT_HOST: '%'
       MYSQL_DATABASE: '${DB_DATABASE}'
-      MYSQL_USER: '${DB_USERNAME}'
-      MYSQL_PASSWORD: '${DB_PASSWORD}'
       MYSQL_ALLOW_EMPTY_PASSWORD: 1
     volumes:
       - 'sail-mysql:/var/lib/mysql'
@@ -103,7 +101,7 @@ services:
       retries: 3
       timeout: 5s
   selenium:
-    image: 'selenium/standalone-chrome'
+    image: 'selenium/standalone-chromium'
     extra_hosts:
       - 'host.docker.internal:host-gateway'
     volumes:

--- a/resources/js/Pages/Profile/Partials/OAuthClients.vue
+++ b/resources/js/Pages/Profile/Partials/OAuthClients.vue
@@ -633,7 +633,7 @@ watch(selectedTeamId, () => {
                                     <div>
                                         <p class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Client secret</p>
                                         <p class="font-mono text-sm break-all text-slate-900 dark:text-slate-200">
-                                            {{ registrationResult?.secret ?? 'PKCE public client (no secret)' }}
+                                            {{ registrationResult?.secret ?? (registrationResult?.confidential ? 'Secret unavailable — regenerate the client to obtain one' : 'PKCE public client (no secret)') }}
                                         </p>
                                     </div>
                                     <JetSecondaryButton

--- a/resources/js/Pages/Profile/Show.vue
+++ b/resources/js/Pages/Profile/Show.vue
@@ -6,7 +6,6 @@ import LogoutOtherBrowserSessionsForm from '@/Pages/Profile/Partials/LogoutOther
 import TwoFactorAuthenticationForm from '@/Pages/Profile/Partials/TwoFactorAuthenticationForm.vue';
 import UpdatePasswordForm from '@/Pages/Profile/Partials/UpdatePasswordForm.vue';
 import UpdateProfileInformationForm from '@/Pages/Profile/Partials/UpdateProfileInformationForm.vue';
-import OAuthSection from './Partials/OAuthSection.vue';
 
 defineProps({
     confirmsTwoFactorAuthentication: Boolean,

--- a/resources/js/Pages/Teams/Partials/OAuthClientTeamManager.vue
+++ b/resources/js/Pages/Teams/Partials/OAuthClientTeamManager.vue
@@ -60,7 +60,7 @@ const fetchClients = async () => {
 
 const fetchTeams = () => {
     const page = usePage();
-    availableTeams.value = page.props?.auth?.user?.all_teams ?? [];
+    availableTeams.value = page.props?.user?.all_teams ?? [];
     if (!form.invitedTeamId && availableTeams.value.length) {
         form.invitedTeamId = availableTeams.value[0].id;
     }
@@ -193,7 +193,7 @@ onMounted(() => {
 
                     <div class="flex items-center justify-between">
                         <div class="text-sm text-slate-600 dark:text-slate-400">
-                            {{ clients }} client{{ clients.length === 1 ? '' : 's' }}
+                            {{ clients.length }} client{{ clients.length === 1 ? '' : 's' }}
                         </div>
                         <JetSecondaryButton type="button" class="!py-2 px-3" @click="refreshAll">
                             Refresh

--- a/tests/Feature/MachineTokenEndpointsTest.php
+++ b/tests/Feature/MachineTokenEndpointsTest.php
@@ -28,7 +28,8 @@ class MachineTokenEndpointsTest extends TestCase
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         Client::query()->create([
-            'user_id' => $user->id,
+            'user_id' => null,
+            'team_id' => $user->currentTeam->id,
             'name' => 'Machine Client',
             'secret' => 'secret',
             'redirect' => '',
@@ -39,7 +40,8 @@ class MachineTokenEndpointsTest extends TestCase
         ]);
 
         Client::query()->create([
-            'user_id' => $user->id,
+            'user_id' => null,
+            'team_id' => $user->currentTeam->id,
             'name' => 'PKCE Client',
             'secret' => null,
             'redirect' => 'http://localhost/callback',
@@ -61,7 +63,8 @@ class MachineTokenEndpointsTest extends TestCase
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $client = Client::query()->create([
-            'user_id' => $user->id,
+            'user_id' => null,
+            'team_id' => $user->currentTeam->id,
             'name' => 'Machine Client',
             'secret' => 'secret',
             'redirect' => '',

--- a/tests/Feature/OAuthClientsRouteTest.php
+++ b/tests/Feature/OAuthClientsRouteTest.php
@@ -120,6 +120,42 @@ class OAuthClientsRouteTest extends TestCase
         ]);
     }
 
+    public function test_confidential_client_creation_returns_the_secret_and_public_does_not(): void
+    {
+        $owner = User::factory()->create();
+        $team = Team::factory()->create(['user_id' => $owner->id, 'personal_team' => false]);
+        $owner->teams()->attach($team, ['role' => 'admin']);
+        $owner->switchTeam($team);
+
+        $this->actingAs($owner);
+
+        // A confidential client must surface its secret once on creation.
+        $confidential = $this->postJson('/oauth/clients', [
+            'team_id' => $team->id,
+            'name' => 'Confidential Client',
+            'redirect' => 'http://localhost/callback',
+            'confidential' => true,
+            'grant_types' => ['authorization_code', 'refresh_token'],
+            'scopes' => ['openid'],
+        ]);
+
+        $confidential->assertOk();
+        $this->assertNotEmpty($confidential->json('secret'));
+
+        // A public (PKCE) client has no secret.
+        $public = $this->postJson('/oauth/clients', [
+            'team_id' => $team->id,
+            'name' => 'Public Client',
+            'redirect' => 'http://localhost/callback',
+            'confidential' => false,
+            'grant_types' => ['authorization_code', 'refresh_token'],
+            'scopes' => ['openid'],
+        ]);
+
+        $public->assertOk();
+        $this->assertEmpty($public->json('secret'));
+    }
+
     public function test_non_owner_cannot_create_update_or_delete_clients(): void
     {
         $owner = User::factory()->create();

--- a/tests/Feature/TeamOAuthInvitesTest.php
+++ b/tests/Feature/TeamOAuthInvitesTest.php
@@ -90,4 +90,56 @@ class TeamOAuthInvitesTest extends TestCase
             'oauth_client_id' => $client->id,
         ]);
     }
+
+    public function test_inviting_a_team_to_a_second_client_does_not_overwrite_the_first(): void
+    {
+        $owner = User::factory()->create();
+        $teamA = Team::factory()->create(['user_id' => $owner->id, 'personal_team' => false]);
+        $teamB = Team::factory()->create(['user_id' => $owner->id, 'personal_team' => false]);
+        $owner->teams()->attach($teamA, ['role' => 'admin']);
+        $owner->teams()->attach($teamB, ['role' => 'admin']);
+
+        $makeClient = fn (string $name) => Client::create([
+            'user_id' => null,
+            'team_id' => $teamA->id,
+            'name' => $name,
+            'secret' => 'secret',
+            'redirect' => 'http://localhost/callback',
+            'personal_access_client' => false,
+            'password_client' => false,
+            'revoked' => false,
+        ]);
+
+        $clientOne = $makeClient('Client One');
+        $clientTwo = $makeClient('Client Two');
+
+        $this->actingAs($owner);
+
+        $this->post("/teams/{$teamA->id}/oauth-clients/{$clientOne->id}/invite-team", [
+            'invited_team_id' => $teamB->id,
+            'role' => 'login',
+        ])->assertStatus(204);
+
+        // Inviting the same team to a second client must not overwrite the first grant.
+        $this->post("/teams/{$teamA->id}/oauth-clients/{$clientTwo->id}/invite-team", [
+            'invited_team_id' => $teamB->id,
+            'role' => 'login',
+        ])->assertStatus(204);
+
+        $this->assertDatabaseHas('oauth_client_team_invitations', [
+            'inviting_team_id' => $teamA->id,
+            'invited_team_id' => $teamB->id,
+            'oauth_client_id' => $clientOne->id,
+        ]);
+        $this->assertDatabaseHas('oauth_client_team_invitations', [
+            'inviting_team_id' => $teamA->id,
+            'invited_team_id' => $teamB->id,
+            'oauth_client_id' => $clientTwo->id,
+        ]);
+
+        $this->assertSame(2, DB::table('oauth_client_team_invitations')
+            ->where('inviting_team_id', $teamA->id)
+            ->where('invited_team_id', $teamB->id)
+            ->count());
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a set of bugs found while testing OAuth client creation (all grant types) and team-based client grants end to end in the browser.

| # | Bug | Fix |
|---|-----|-----|
| 1 | Confidential client secret never shown (dialog always said *"PKCE public client (no secret)"*) — `store()` returned `$client->fresh()`, dropping Passport's `plainSecret` | Surface the hidden `secret` once on creation; frontend distinguishes confidential vs public in the fallback |
| 2 | Machine-tokens dropdown always empty | Clients are team-owned (`user_id` is null), so team-scope `clients()` / `generate()` / `tokens()` / `revoke()` |
| 3 | Team-grant invite dropdown always empty | Read teams from `user.all_teams` (props expose no `auth` key) |
| 4 | Granting a team to a 2nd client **overwrote** the 1st (data loss) | `belongsToMany` sync keyed only on `invited_team_id`; replaced with an upsert on `(inviting, invited, client)` |
| 5 | Footer rendered the raw `clients` array | Render `clients.length` |

## Dead code removed
- `Team::invitedTeams()` relationship (no remaining callers after #4)
- Unused `OAuthSection` import in `Profile/Show.vue`

## Infrastructure
- `docker-compose`: publish to container port **8000** (where the app serves; was `:80` → connection reset) and drop the invalid `MYSQL_USER=root` env that crash-looped MySQL 8

## Verification
All fixes confirmed through the running app via browser automation:
- Created clients for **Authorization Code + Refresh** (public & confidential), **Client Credentials**, and **Device / TV**
- Confidential client now shows its secret in the dialog
- Client-credentials client appears in the machine-tokens dropdown; generated a token via the UI
- Granted **and** revoked team access through the UI; two grants to different clients now persist as two rows
- PHP lints clean; frontend rebuilds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)