### PR TITLE
GAIA sign-in polish: opaque gaia id + DRY scopes

### DIFF
--- a/app/Gaia/GaiaIdentity.php
+++ b/app/Gaia/GaiaIdentity.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Gaia;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+
+/**
+ * Stable, opaque, non-enumerable GAIA id for a user.
+ *
+ * Replaces exposing the sequential primary key as the `obfuscatedid`/`id` (which
+ * is enumerable; Google's gaia id is opaque). Derived via HMAC over the user's
+ * key with APP_KEY, so it is:
+ *   - stable per user (same on every device/sign-in),
+ *   - opaque / non-enumerable,
+ *   - not a database round-trip and needs no migration.
+ *
+ * Stability is tied to APP_KEY, which is already part of the trust base (it also
+ * encrypts the sync seed) — rotating APP_KEY resets derived identity, same as it
+ * resets the seed.
+ *
+ * MUST be used identically for the `google-accounts-signin` header obfuscatedid
+ * and the userinfo `id` so the two stay coupled.
+ */
+final class GaiaIdentity
+{
+    public static function for(Authenticatable $user): string
+    {
+        return hash_hmac('sha256', (string) $user->getAuthIdentifier(), (string) config('app.key'));
+    }
+}

--- a/app/Gaia/GaiaScopes.php
+++ b/app/Gaia/GaiaScopes.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Gaia;
+
+/**
+ * Single source of truth for the GAIA scopes openFyde/ChromeOS uses.
+ *
+ * These are the literal Google scope strings Chromium requests verbatim. They
+ * were previously duplicated in config/openid.php (as tokens_can) and
+ * config/gaia.php (the sign-in scope list); both now derive from here.
+ */
+final class GaiaScopes
+{
+    /**
+     * GAIA scopes + their consent descriptions. Merged into openid.passport.tokens_can
+     * so Passport/GaiaScopeRepository recognize them at grant time.
+     */
+    public const DESCRIPTIONS = [
+        'https://www.google.com/accounts/OAuthLogin' => 'Sign in to your openFyde device',
+        'https://www.googleapis.com/auth/chromesync' => 'Sync your openFyde browser and OS state',
+        'https://www.googleapis.com/auth/userinfo.email' => 'See your email address (openFyde)',
+        'https://www.googleapis.com/auth/userinfo.profile' => 'See your basic profile info (openFyde)',
+        // Deferred (enterprise enrollment only; consumer sign-in skips DM):
+        'https://www.googleapis.com/auth/chromeosdevicemanagement' => 'Enroll this device in management',
+    ];
+
+    /**
+     * Scopes the sign-in authorization code / token requests: the standard OIDC
+     * identity scopes plus the GAIA ones the device needs (sign-in + sync).
+     * (DM enrollment is omitted here — consumer sign-in doesn't request it.)
+     */
+    public const SIGN_IN = [
+        'openid',
+        'email',
+        'https://www.google.com/accounts/OAuthLogin',
+        'https://www.googleapis.com/auth/chromesync',
+        'https://www.googleapis.com/auth/userinfo.email',
+        'https://www.googleapis.com/auth/userinfo.profile',
+    ];
+}

--- a/app/Http/Controllers/Gaia/EmbeddedSetupController.php
+++ b/app/Http/Controllers/Gaia/EmbeddedSetupController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Gaia;
 
+use App\Gaia\GaiaIdentity;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cookie;
@@ -38,7 +39,7 @@ class EmbeddedSetupController extends Controller
         $user = $request->user(); // guaranteed by the auth middleware
 
         $email = strtolower((string) $user->email);
-        $gaiaId = (string) $user->getKey();
+        $gaiaId = GaiaIdentity::for($user); // opaque + stable; coupled with userinfo `id`
 
         try {
             $authCode = $this->mintAuthCode($user);

--- a/app/Http/Controllers/Gaia/UserinfoController.php
+++ b/app/Http/Controllers/Gaia/UserinfoController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Gaia;
 
+use App\Gaia\GaiaIdentity;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -33,7 +34,9 @@ class UserinfoController extends Controller
         }
 
         return response()->json([
-            'id' => (string) $user->getKey(),
+            // Opaque, stable gaia id — coupled with the obfuscatedid emitted in
+            // the sign-in header (App\Gaia\GaiaIdentity). NOT the sequential PK.
+            'id' => GaiaIdentity::for($user),
             'email' => $user->email,
             'verified_email' => (bool) $user->email_verified_at,
         ]);

--- a/config/gaia.php
+++ b/config/gaia.php
@@ -24,14 +24,8 @@ return [
     // validation.
     'redirect_uri' => env('GAIA_CHROMEOS_REDIRECT_URI', 'https://chromeos.localhost/oauth2/callback'),
 
-    // Scopes minted for the sign-in token — the literal GAIA scope strings
-    // Chromium requests. Kept in sync with config/openid.php `tokens_can`.
-    'scopes' => [
-        'openid',
-        'email',
-        'https://www.google.com/accounts/OAuthLogin',
-        'https://www.googleapis.com/auth/chromesync',
-        'https://www.googleapis.com/auth/userinfo.email',
-        'https://www.googleapis.com/auth/userinfo.profile',
-    ],
+    // Scopes minted for the sign-in token. Single source of truth lives in
+    // App\Gaia\GaiaScopes; config/openid.php tokens_can derives from the same
+    // class, so the GAIA scope strings aren't duplicated.
+    'scopes' => \App\Gaia\GaiaScopes::SIGN_IN,
 ];

--- a/config/openid.php
+++ b/config/openid.php
@@ -9,7 +9,7 @@ return [
          * Place your Passport and OpenID Connect scopes here.
          * To receive an `id_token, you should at least provide the openid scope.
          */
-        'tokens_can' => [
+        'tokens_can' => array_merge([
             'openid' => 'Enable OpenID Connect',
             'name' => 'Can access your name',
             'profile' => 'Information about your profile',
@@ -17,19 +17,14 @@ return [
             'address' => 'Information about your address',
             'sync' => 'Release your sync-chain seed for self-hosted device sync',
             // 'login' => 'See your login information',
-
-            // ChromeOS / GAIA-compat scopes. openFyde's Chromium requests these
-            // literal Google scope strings verbatim during sign-in, Chrome Sync,
-            // and device management (it speaks GAIA, repointed at us via
-            // --fydeos-gaia-url/--fydeos-apis-url). Registered so Passport will
-            // mint tokens for them. See the fyde-fork repo's docs/gaia-shim-spike.md.
-            'https://www.google.com/accounts/OAuthLogin' => 'Sign in to your openFyde device',
-            'https://www.googleapis.com/auth/chromesync' => 'Sync your openFyde browser and OS state',
-            'https://www.googleapis.com/auth/userinfo.email' => 'See your email address (openFyde)',
-            'https://www.googleapis.com/auth/userinfo.profile' => 'See your basic profile info (openFyde)',
-            // Deferred (enterprise enrollment only; consumer sign-in skips DM):
-            'https://www.googleapis.com/auth/chromeosdevicemanagement' => 'Enroll this device in management',
         ],
+            // ChromeOS / GAIA-compat scopes — the literal Google scope strings
+            // openFyde's Chromium requests verbatim (it speaks GAIA, repointed at
+            // us via --fydeos-gaia-url/--fydeos-apis-url). Single source of truth
+            // in App\Gaia\GaiaScopes (shared with config/gaia.php). Registered
+            // here so Passport/GaiaScopeRepository mint tokens for them.
+            \App\Gaia\GaiaScopes::DESCRIPTIONS
+        ),
     ],
 
     /**

--- a/tests/Feature/GaiaEmbeddedSetupTest.php
+++ b/tests/Feature/GaiaEmbeddedSetupTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Gaia\GaiaIdentity;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -51,7 +52,9 @@ class GaiaEmbeddedSetupTest extends TestCase
         $header = $response->headers->get('google-accounts-signin');
         $this->assertNotNull($header, 'google-accounts-signin header must be present');
         $this->assertStringContainsString('email="user@aut.hair"', $header);
-        $this->assertStringContainsString('obfuscatedid="'.$user->id.'"', $header);
+        // Opaque gaia id (coupled with userinfo `id`), not the sequential PK.
+        $this->assertStringContainsString('obfuscatedid="'.GaiaIdentity::for($user).'"', $header);
+        $this->assertStringNotContainsString('obfuscatedid="'.$user->id.'"', $header);
         $this->assertStringContainsString('sessionindex=0', $header);
 
         // oauth_code cookie (the auth code the browser exchanges later).

--- a/tests/Feature/GaiaUserinfoTest.php
+++ b/tests/Feature/GaiaUserinfoTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Gaia\GaiaIdentity;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Passport\Passport;
@@ -44,10 +45,13 @@ class GaiaUserinfoTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertExactJson([
-            'id' => (string) $user->id,
+            'id' => GaiaIdentity::for($user),
             'email' => 'user@aut.hair',
             'verified_email' => true,
         ]);
+
+        // The id must be opaque, not the enumerable primary key.
+        $this->assertNotEquals((string) $user->id, $response->json('id'));
     }
 
     public function test_userinfo_omits_hosted_domain_so_consumer_skips_dm(): void


### PR DESCRIPTION
Follow-up to #40 (post-v1.6.0). Addresses two low-priority items from the #40 review; the deeper/on-device-coupled ones are deliberately deferred.

## Changes
- **Opaque gaia id (#2)** — `App\\Gaia\\GaiaIdentity` derives a stable, opaque, non-enumerable id via `HMAC(user key, APP_KEY)` instead of exposing the sequential primary key. No migration; stability is tied to `APP_KEY` (already trust-base — it encrypts the sync seed). Used identically for the `google-accounts-signin` header `obfuscatedid` and the userinfo `id` (kept coupled).
- **DRY scopes (#4)** — `App\\Gaia\\GaiaScopes` is the single source of truth; `config/openid.php` `tokens_can` and `config/gaia.php` both derive from it (the GAIA scope strings were duplicated).

## Deferred (intentionally)
- **userinfo scope-gating parity** — risks breaking on-device userinfo if the token's actual scope is guessed wrong; wants the `cros vm` run to confirm.
- **postMessage origin allowlist** — tighten before real data flows (harmless while `services` is `[]`).

## Tests
Existing GAIA tests updated to assert the opaque id (and that it is **not** the PK); scopes still validate end-to-end (the e2e chromesync-scope assertion is unchanged).

## Note
Behavior change: the gaia id format changes from the PK to the opaque value. Safe now (no devices enrolled yet); merge before any device signs in.