### PR TITLE
Capture the OOBE password via SAML mode so ChromeOS doesn't powerwash

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -38,6 +38,10 @@ class Kernel extends HttpKernel
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \App\Http\Middleware\HandleInertiaRequests::class,
+            // openFyde/ChromeOS GAIA OOBE: emit google-accounts-saml + the
+            // gaia_saml_api handshake on /login so ChromeOS captures the password
+            // (cryptohome factor). No-op outside the GAIA flow.
+            \App\Http\Middleware\GaiaSamlMode::class,
         ],
         'api' => [
             \Illuminate\Routing\Middleware\ThrottleRequests::class.':api',

--- a/app/Http/Middleware/GaiaSamlMode.php
+++ b/app/Http/Middleware/GaiaSamlMode.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Puts ChromeOS into SAML mode during the openFyde GAIA OOBE flow so it captures
+ * the password the user types as the cryptohome "gaia" knowledge factor.
+ *
+ * Why this exists: ChromeOS derives the encrypted-home key from the typed
+ * password, never from the OAuth token. If sign-in completes with no password
+ * captured (a "passwordless owner"), ChromeOS arms a silent powerwash and wipes
+ * the device on the next boot. SAML mode — and therefore password capture — is
+ * gated entirely by one response header (`google-accounts-saml`, presence-based;
+ * traced from the openFyde r132 tree, saml_handler.js). We emit it on the login
+ * page and run the Chrome Credentials Passing API (`gaia_saml_api`) handshake to
+ * hand ChromeOS the password explicitly.
+ *
+ * Scoped to the GAIA flow via a session flag set when /embedded/setup is hit
+ * (even when the unauthenticated device is bounced to /login), so normal web
+ * logins are unaffected. No-op outside the flow and in any non-ChromeOS browser
+ * (nothing listens for the gaia_saml_api messages there).
+ */
+class GaiaSamlMode
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        // SAML mode + password capture belong on the login page (where the
+        // password field lives), and only inside the GAIA OOBE flow. We detect
+        // the flow via Laravel's intended-URL: when an unauthenticated device
+        // hits /embedded/setup, `auth` stores that URL as `url.intended` for the
+        // post-login redirect — a signal guaranteed to survive the bounce. The
+        // completion page (/embedded/setup) stays a plain GAIA response so the
+        // existing google-accounts-signin + oauth_code path finishes sign-in.
+        if ($request->routeIs('login') && $this->isGaiaFlow($request)) {
+            $response->headers->set('google-accounts-saml', parse_url((string) config('app.url'), PHP_URL_HOST) ?: 'aut.hair');
+            $this->injectHandshake($response);
+        }
+
+        return $response;
+    }
+
+    private function isGaiaFlow(Request $request): bool
+    {
+        if (! $request->hasSession()) {
+            return false;
+        }
+
+        return str_contains((string) $request->session()->get('url.intended', ''), 'embedded/setup/v2/chromeos');
+    }
+
+    private function injectHandshake(Response $response): void
+    {
+        $content = $response->getContent();
+
+        if (! is_string($content)
+            || ! str_contains((string) $response->headers->get('Content-Type'), 'text/html')
+            || ! str_contains($content, '</body>')) {
+            return;
+        }
+
+        $response->setContent(str_replace('</body>', $this->script().'</body>', $content));
+    }
+
+    /**
+     * The Chrome Credentials Passing API handshake (gaia_saml_api): initialize
+     * the API, then on form submit hand the typed password to ChromeOS as a
+     * KEY_TYPE_PASSWORD_PLAIN credential (add + confirm). authenticator.js reads
+     * this at maybeCompleteAuth_ and sets it as the cryptohome factor — taking
+     * priority over DOM scraping. A no-op in any browser that isn't ChromeOS in
+     * SAML mode (nothing forwards the messages).
+     */
+    private function script(): string
+    {
+        return <<<'HTML'
+<script>
+(function () {
+    if (window.__gaiaSamlApi) return; window.__gaiaSamlApi = true;
+    var TOKEN = 'authair-password';
+    function call(c) { window.postMessage({ type: 'gaia_saml_api', call: c }, window.location.origin); }
+    // v1 is the only supported version (saml_handler.js MIN/MAX_API_VERSION_VERSION = 1).
+    call({ method: 'initialize', requestedVersion: 1 });
+    function handOff(pw) {
+        if (!pw) return;
+        call({ method: 'add', token: TOKEN, keyType: 'KEY_TYPE_PASSWORD_PLAIN', passwordBytes: pw });
+        call({ method: 'confirm', token: TOKEN });
+    }
+    // Capture phase: read the password before the SPA's submit handler clears it.
+    document.addEventListener('submit', function () {
+        var input = document.querySelector('input[type="password"]');
+        if (input) { handOff(input.value); }
+    }, true);
+})();
+</script>
+HTML;
+    }
+}

--- a/app/Http/Middleware/GaiaSamlMode.php
+++ b/app/Http/Middleware/GaiaSamlMode.php
@@ -14,10 +14,11 @@ use Symfony\Component\HttpFoundation\Response;
  * password, never from the OAuth token. If sign-in completes with no password
  * captured (a "passwordless owner"), ChromeOS arms a silent powerwash and wipes
  * the device on the next boot. SAML mode — and therefore password capture — is
- * gated entirely by one response header (`google-accounts-saml`, presence-based;
- * traced from the openFyde r132 tree, saml_handler.js). We emit it on the login
- * page and run the Chrome Credentials Passing API (`gaia_saml_api`) handshake to
- * hand ChromeOS the password explicitly.
+ * gated entirely by one response header: `google-accounts-saml: start` turns it
+ * on, `: end` turns it off (the value is matched, not just the header's presence;
+ * saml_handler.js:823-830 in the openFyde r132 tree). We emit `start` on the
+ * login page and run the Chrome Credentials Passing API (`gaia_saml_api`)
+ * handshake to hand ChromeOS the password explicitly.
  *
  * Scoped to the GAIA flow via a session flag set when /embedded/setup is hit
  * (even when the unauthenticated device is bounced to /login), so normal web
@@ -38,7 +39,9 @@ class GaiaSamlMode
         // completion page (/embedded/setup) stays a plain GAIA response so the
         // existing google-accounts-signin + oauth_code path finishes sign-in.
         if ($request->routeIs('login') && $this->isGaiaFlow($request)) {
-            $response->headers->set('google-accounts-saml', parse_url((string) config('app.url'), PHP_URL_HOST) ?: 'aut.hair');
+            // Must be exactly "start" — ChromeOS lowercases and matches the value
+            // against start/end; anything else is ignored and SAML mode never arms.
+            $response->headers->set('google-accounts-saml', 'start');
             $this->injectHandshake($response);
         }
 

--- a/tests/Feature/GaiaSamlModeTest.php
+++ b/tests/Feature/GaiaSamlModeTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * SAML mode for the openFyde/ChromeOS GAIA OOBE flow: ChromeOS only captures the
+ * typed password (the cryptohome factor that prevents the silent powerwash) when
+ * the login page emits `google-accounts-saml` and runs the gaia_saml_api
+ * handshake. That must happen ONLY inside the GAIA flow, never for normal logins.
+ */
+class GaiaSamlModeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'passport.public_key' => base_path('tests/Feature/test-public.key'),
+            'passport.private_key' => base_path('tests/Feature/test-private.key'),
+        ]);
+    }
+
+    public function test_a_normal_login_is_not_put_into_saml_mode(): void
+    {
+        $response = $this->get('/login');
+
+        $response->assertStatus(200);
+        $this->assertNull($response->headers->get('google-accounts-saml'));
+        $response->assertDontSee('gaia_saml_api', false);
+    }
+
+    public function test_embedded_setup_marks_the_flow_and_login_enters_saml_mode(): void
+    {
+        // An unauthenticated device hitting the GAIA entry point is bounced to
+        // login; `auth` records the GAIA page as the intended URL.
+        $this->get(route('gaia.embedded-setup'))
+            ->assertRedirect(route('login'))
+            ->assertSessionHas('url.intended');
+
+        // The login page (same session) now emits the SAML header and the
+        // Credentials Passing API handshake so ChromeOS captures the password.
+        $login = $this->get('/login');
+
+        $login->assertStatus(200);
+        $this->assertNotNull($login->headers->get('google-accounts-saml'));
+        $login->assertSee('gaia_saml_api', false);
+        $login->assertSee('KEY_TYPE_PASSWORD_PLAIN', false);
+    }
+
+    public function test_the_completion_page_is_not_in_saml_mode(): void
+    {
+        // gaia.client_id is unset in tests, so the controller takes the placeholder
+        // path (no Passport keys/client needed) and returns the page.
+        $user = User::factory()->create(['email_verified_at' => now()]);
+
+        $response = $this->actingAs($user)->get(route('gaia.embedded-setup'));
+
+        $response->assertStatus(200);
+        // The completion page stays a plain GAIA response (SAML belongs on /login).
+        $this->assertNull($response->headers->get('google-accounts-saml'));
+    }
+}

--- a/tests/Feature/GaiaSamlModeTest.php
+++ b/tests/Feature/GaiaSamlModeTest.php
@@ -48,7 +48,8 @@ class GaiaSamlModeTest extends TestCase
         $login = $this->get('/login');
 
         $login->assertStatus(200);
-        $this->assertNotNull($login->headers->get('google-accounts-saml'));
+        // Must be exactly "start" — ChromeOS matches the value, not mere presence.
+        $this->assertSame('start', $login->headers->get('google-accounts-saml'));
         $login->assertSee('gaia_saml_api', false);
         $login->assertSee('KEY_TYPE_PASSWORD_PLAIN', false);
     }


### PR DESCRIPTION
## Why

After the OAuth/token flow was fully working (auth-code exchange **200**, refresh **200**), the device still failed OOBE: two successful token exchanges, then it came back to `/login` **factory-fresh**. That wasn't a session or handshake loop — it was a **silent powerwash**.

Root cause (traced from the openFyde r132 Chromium tree): ChromeOS keys the encrypted home directory from a **`"gaia"` knowledge factor derived from the password the user types** — never from the OAuth token. The authenticator stores it in `password_`. If sign-in completes with `password_` null (a "passwordless owner"), ChromeOS arms `kSilentPowerwash` and wipes on next boot. Our shim completed via the pure GAIA path and never populated `password_`.

## What

Password capture is gated by one response header — **`google-accounts-saml`**, whose **value is matched**: `start` turns SAML mode on, `end` off (`saml_handler.js:823-830`). Once in SAML mode, ChromeOS takes the password via DOM scraping or, preferably, the explicit **Chrome Credentials Passing API** (`gaia_saml_api`), which is checked **first** in `maybeCompleteAuth_` and is immune to page markup.

This PR adds one middleware, `GaiaSamlMode`, scoped to the GAIA OOBE flow:

1. **Emits `google-accounts-saml: start`** on `/login` → ChromeOS enters SAML mode.
2. **Injects the `gaia_saml_api` handshake** into the login HTML:
   `initialize` (v1) on load → on form submit, `add` (`KEY_TYPE_PASSWORD_PLAIN`, `passwordBytes`) → `confirm`.
   The typed password is handed to ChromeOS explicitly, read at `authenticator.js maybeCompleteAuth_`, and set as the cryptohome factor → **no powerwash**.

The completion page (`/embedded/setup`) stays a plain GAIA response, so the existing `google-accounts-signin` + `oauth_code` path is **untouched** — we're *adding* password capture, not changing the token flow.

## Scoping (no impact on normal logins)

Detection keys off Laravel's **`url.intended`** — set when an unauthenticated device is bounced from `/embedded/setup` to `/login`, and guaranteed to survive the auth redirect. SAML mode + the handshake appear **only** inside the GAIA flow; a normal web login is never affected. It's also a no-op in any non-ChromeOS browser (nothing forwards the `gaia_saml_api` messages).

## Tests

`GaiaSamlModeTest` (3 cases): the `google-accounts-saml: start` header (asserted by exact value) + the handshake appear on `/login` **only** inside the flow — never on a normal login, never on the completion page. Full suite: **117 passed, 4 skipped**.

The handshake itself can't be unit-tested (the `gaia_saml_api` forwarder only exists in ChromeOS's SAML-injected context), so the device is the real test.

## Review fix applied

The first revision emitted the app host as the header value; ChromeOS matches the value against `start`/`end`, so that never armed SAML mode. Fixed to emit exactly **`start`** (commit `888ee61`), with the test asserting the exact value.

## ⚠️ Still needs on-device validation

Acceptance test: the device retains the password and skips the powerwash. Remaining lower-confidence points (in likelihood order):

1. **Submit capture** — the password is read on the form's `submit` event (capture phase, before the SPA clears it). Jetstream's `<form @submit.prevent>` dispatches `submit`; worth confirming `add`/`confirm` fire before the POST round-trip so `waitApiPasswordConfirm_` clears before `closeView`.
2. **`initialize` is fire-and-forget** (not awaiting the `gaia_saml_api_reply` `initialized`). Low risk — the channel daemon connects during OOBE before the user can submit, and `add`/`confirm` have no `apiInitialized_` guard — but the robust version would await the reply. Reasonable as a first attempt.
3. **2FA** — the password is on the first screen (captured on its submit); the 2FA screen has no password field, so it's unaffected — noted for completeness.

## Context

Follows the merged GAIA work (#40, #42) and device-tracking (#43), and the token-flow fixes already landed (redirect_uri default, refresh-scope clamp). This is the last known blocker to a clean OOBE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)