### PR TITLE
Fix powerwash: /embedded/setup must return HTML (not 302) for SAML loadcommit timing

### DIFF
--- a/app/Http/Controllers/Gaia/EmbeddedSetupController.php
+++ b/app/Http/Controllers/Gaia/EmbeddedSetupController.php
@@ -37,7 +37,39 @@ class EmbeddedSetupController extends Controller
 
     public function __invoke(Request $request)
     {
-        $user = $request->user(); // guaranteed by the auth middleware
+        // Unauthenticated OOBE webview: return the SAML bootstrap page.
+        //
+        // ChromeOS's PasswordInputScraper is gated by getSAMLFlag, which queries
+        // isSamlPage_ at document_start. Content scripts run BEFORE loadcommit
+        // fires for the same page, so isSamlPage_ always reflects the PREVIOUS
+        // page's loadcommit. With a server-side 302 (/embedded/setup → /login)
+        // there is no loadcommit for /embedded/setup, meaning isSamlPage_ is
+        // false when /login's document_start fires and the scraper never inits.
+        //
+        // Fix: serve a real HTML page here (not a redirect) with
+        // google-accounts-saml: start. This gives ChromeOS a loadcommit for
+        // /embedded/setup (isSamlPage_ = true). When the JS redirect to /login
+        // fires, /login's document_start sees isSamlPage_ = true → scraper inits →
+        // password captured → no powerwash. This mirrors real enterprise SAML:
+        // GAIA emits the header on its own HTML page, gets its own loadcommit,
+        // then the IdP's document_start inherits isSamlPage_ = true.
+        if (! $request->user()) {
+            if ($request->hasSession()) {
+                $request->session()->put('url.intended', $request->fullUrl());
+            }
+
+            $loginUrl = json_encode(route('login'), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG);
+
+            return response(
+                '<!doctype html><html><head><meta charset="utf-8"></head><body>'
+                . "<script>window.location.replace($loginUrl);</script>"
+                . '</body></html>',
+                200
+            )->header('Content-Type', 'text/html; charset=utf-8')
+             ->header('google-accounts-saml', 'start');
+        }
+
+        $user = $request->user();
 
         // L1: fail closed if the device is built for a DIFFERENT OAuth client than
         // the one we provisioned. Validate only when the param is present (the

--- a/app/Http/Middleware/GaiaSamlMode.php
+++ b/app/Http/Middleware/GaiaSamlMode.php
@@ -13,17 +13,52 @@ use Symfony\Component\HttpFoundation\Response;
  * Why this exists: ChromeOS derives the encrypted-home key from the typed
  * password, never from the OAuth token. If sign-in completes with no password
  * captured (a "passwordless owner"), ChromeOS arms a silent powerwash and wipes
- * the device on the next boot. SAML mode — and therefore password capture — is
- * gated entirely by one response header: `google-accounts-saml: start` turns it
- * on, `: end` turns it off (the value is matched, not just the header's presence;
- * saml_handler.js:823-830 in the openFyde r132 tree). We emit `start` on the
- * login page and run the Chrome Credentials Passing API (`gaia_saml_api`)
- * handshake to hand ChromeOS the password explicitly.
+ * the device on the next boot. SAML mode is gated entirely by one response
+ * header: `google-accounts-saml: start` turns it on, `: end` turns it off (the
+ * value is matched, not just presence; saml_handler.js:823-830 in the openFyde
+ * r132 tree).
  *
- * Scoped to the GAIA flow via a session flag set when /embedded/setup is hit
- * (even when the unauthenticated device is bounced to /login), so normal web
- * logins are unaffected. No-op outside the flow and in any non-ChromeOS browser
- * (nothing listens for the gaia_saml_api messages there).
+ * Once in SAML mode ChromeOS's injected PasswordInputScraper (saml_injected.js)
+ * auto-scrapes any input[type=password] on the login page and stores the value in
+ * passwordStore_ on the handler side — this persists across the /login →
+ * /embedded/setup navigation because samlHandler_.reset() is never called between
+ * those two pages. When maybeCompleteAuth_ runs after the token exchange it finds
+ * scrapedPasswordCount === 1 and sets password_ = firstScrapedPassword, which
+ * becomes the cryptohome factor.
+ *
+ * We do NOT inject the Chrome Credentials Passing API (gaia_saml_api) handshake.
+ * The API's `add` call sets samlApiUsed = true (overriding scraping) but `confirm`
+ * is sent on form submit — it is lost when the page navigates before the extension
+ * channel round-trip completes. With samlApiUsed true and confirmToken_ null,
+ * apiPasswordBytes returns null and password_ ends up null → powerwash. The DOM
+ * scraper avoids this race entirely because it fires on keystroke, not on submit.
+ *
+ * THE TIMING PROBLEM (why /embedded/setup must return HTML, not a 302):
+ *
+ * ChromeOS injects saml_injected.js at `document_start` for every page in the
+ * webview (saml_handler.js:382-390). At document_start, it immediately sends a
+ * `getSAMLFlag` RPC (saml_injected.js:214). The handler responds with
+ * `this.isSamlPage_` (saml_handler.js:1026). `isSamlPage_` is only updated at
+ * `loadcommit` (saml_handler.js:572). In Chromium's architecture, document_start
+ * content scripts run in the renderer during document creation, and `loadcommit`
+ * fires only after the browser process receives DidCommitNavigation from the
+ * renderer — so content scripts always run BEFORE loadcommit for the same page.
+ *
+ * Consequence: when /login's content scripts query getSAMLFlag, isSamlPage_
+ * reflects the PREVIOUS page's loadcommit (initial state = false), not /login's
+ * own pendingIsSamlPage_. The PasswordInputScraper is never initialized and the
+ * device powerwashes.
+ *
+ * Fix: serve a real HTML page at /embedded/setup (not a 302) that carries
+ * google-accounts-saml: start and JS-redirects to /login. This gives ChromeOS a
+ * loadcommit for /embedded/setup (isSamlPage_ = true). When the browser then
+ * follows the JS redirect to /login, document_start fires before /login's
+ * loadcommit — but now isSamlPage_ is true (from /embedded/setup's loadcommit),
+ * so the scraper initializes, captures the typed password, and stops the powerwash.
+ *
+ * This mirrors how real enterprise SAML works: GAIA (accounts.google.com) emits
+ * the header and gets its own loadcommit; the actual IdP page's document_start
+ * then sees isSamlPage_ = true from GAIA's prior loadcommit.
  */
 class GaiaSamlMode
 {
@@ -31,18 +66,31 @@ class GaiaSamlMode
     {
         $response = $next($request);
 
-        // SAML mode + password capture belong on the login page (where the
-        // password field lives), and only inside the GAIA OOBE flow. We detect
-        // the flow via Laravel's intended-URL: when an unauthenticated device
-        // hits /embedded/setup, `auth` stores that URL as `url.intended` for the
-        // post-login redirect — a signal guaranteed to survive the bounce. The
-        // completion page (/embedded/setup) stays a plain GAIA response so the
-        // existing google-accounts-signin + oauth_code path finishes sign-in.
+        // When an unauthenticated ChromeOS webview hits /embedded/setup, Laravel's
+        // auth middleware returns a 302 to /login. We replace that 302 with an HTML
+        // page that carries google-accounts-saml: start and JS-redirects to /login.
+        // See the class docblock for why a JS redirect is required (loadcommit
+        // timing — a server-side 302 does not produce its own loadcommit event).
+        if ($request->routeIs('gaia.embedded-setup') && $response->isRedirect()) {
+            $loginUrl = json_encode(
+                $response->getTargetUrl(),
+                JSON_UNESCAPED_SLASHES | JSON_HEX_TAG
+            );
+
+            return response(
+                '<!doctype html><html><head><meta charset="utf-8"></head><body>'
+                . "<script>window.location.replace($loginUrl);</script>"
+                . '</body></html>',
+                200
+            )->header('Content-Type', 'text/html; charset=utf-8')
+             ->header('google-accounts-saml', 'start');
+        }
+
+        // Belt-and-suspenders: also emit the header on the login page itself.
+        // Keeps pendingIsSamlPage_ = true throughout the /login navigation so
+        // isSamlPage_ remains true at /login's loadcommit and beyond.
         if ($request->routeIs('login') && $this->isGaiaFlow($request)) {
-            // Must be exactly "start" — ChromeOS lowercases and matches the value
-            // against start/end; anything else is ignored and SAML mode never arms.
             $response->headers->set('google-accounts-saml', 'start');
-            $this->injectHandshake($response);
         }
 
         return $response;
@@ -55,51 +103,5 @@ class GaiaSamlMode
         }
 
         return str_contains((string) $request->session()->get('url.intended', ''), 'embedded/setup/v2/chromeos');
-    }
-
-    private function injectHandshake(Response $response): void
-    {
-        $content = $response->getContent();
-
-        if (! is_string($content)
-            || ! str_contains((string) $response->headers->get('Content-Type'), 'text/html')
-            || ! str_contains($content, '</body>')) {
-            return;
-        }
-
-        $response->setContent(str_replace('</body>', $this->script().'</body>', $content));
-    }
-
-    /**
-     * The Chrome Credentials Passing API handshake (gaia_saml_api): initialize
-     * the API, then on form submit hand the typed password to ChromeOS as a
-     * KEY_TYPE_PASSWORD_PLAIN credential (add + confirm). authenticator.js reads
-     * this at maybeCompleteAuth_ and sets it as the cryptohome factor — taking
-     * priority over DOM scraping. A no-op in any browser that isn't ChromeOS in
-     * SAML mode (nothing forwards the messages).
-     */
-    private function script(): string
-    {
-        return <<<'HTML'
-<script>
-(function () {
-    if (window.__gaiaSamlApi) return; window.__gaiaSamlApi = true;
-    var TOKEN = 'authair-password';
-    function call(c) { window.postMessage({ type: 'gaia_saml_api', call: c }, window.location.origin); }
-    // v1 is the only supported version (saml_handler.js MIN/MAX_API_VERSION_VERSION = 1).
-    call({ method: 'initialize', requestedVersion: 1 });
-    function handOff(pw) {
-        if (!pw) return;
-        call({ method: 'add', token: TOKEN, keyType: 'KEY_TYPE_PASSWORD_PLAIN', passwordBytes: pw });
-        call({ method: 'confirm', token: TOKEN });
-    }
-    // Capture phase: read the password before the SPA's submit handler clears it.
-    document.addEventListener('submit', function () {
-        var input = document.querySelector('input[type="password"]');
-        if (input) { handOff(input.value); }
-    }, true);
-})();
-</script>
-HTML;
     }
 }

--- a/app/Http/Middleware/GaiaSamlMode.php
+++ b/app/Http/Middleware/GaiaSamlMode.php
@@ -4,6 +4,7 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -64,25 +65,17 @@ class GaiaSamlMode
 {
     public function handle(Request $request, Closure $next): Response
     {
-        // Laravel's Authenticate middleware throws AuthenticationException rather
-        // than returning a RedirectResponse. For the /embedded/setup route we need
-        // to intercept that throw so we can return our SAML-initialising HTML page
-        // instead of letting the exception handler produce a plain 302.
-        try {
-            $response = $next($request);
-        } catch (\Illuminate\Auth\AuthenticationException $e) {
-            if (! $request->routeIs('gaia.embedded-setup')) {
-                throw $e;
-            }
-
+        // For the GAIA embedded setup route, handle unauthenticated requests HERE
+        // before calling $next() — not after. Laravel's Authenticate middleware
+        // throws AuthenticationException rather than returning a RedirectResponse,
+        // so any post-$next() check is unreachable for unauthenticated requests.
+        // StartSession runs before us in the web group, so Auth::check() correctly
+        // reads session state without needing $next() to run first.
+        if ($request->routeIs('gaia.embedded-setup') && ! Auth::check()) {
             return $this->samlRedirectPage($request);
         }
 
-        // Fallback for any non-throw redirect (guard implementations that return
-        // a RedirectResponse rather than throwing).
-        if ($request->routeIs('gaia.embedded-setup') && $response->isRedirect()) {
-            return $this->samlRedirectPage($request);
-        }
+        $response = $next($request);
 
         // Belt-and-suspenders: also emit the header on the login page itself.
         // Keeps pendingIsSamlPage_ = true throughout the /login navigation so

--- a/app/Http/Middleware/GaiaSamlMode.php
+++ b/app/Http/Middleware/GaiaSamlMode.php
@@ -64,26 +64,24 @@ class GaiaSamlMode
 {
     public function handle(Request $request, Closure $next): Response
     {
-        $response = $next($request);
+        // Laravel's Authenticate middleware throws AuthenticationException rather
+        // than returning a RedirectResponse. For the /embedded/setup route we need
+        // to intercept that throw so we can return our SAML-initialising HTML page
+        // instead of letting the exception handler produce a plain 302.
+        try {
+            $response = $next($request);
+        } catch (\Illuminate\Auth\AuthenticationException $e) {
+            if (! $request->routeIs('gaia.embedded-setup')) {
+                throw $e;
+            }
 
-        // When an unauthenticated ChromeOS webview hits /embedded/setup, Laravel's
-        // auth middleware returns a 302 to /login. We replace that 302 with an HTML
-        // page that carries google-accounts-saml: start and JS-redirects to /login.
-        // See the class docblock for why a JS redirect is required (loadcommit
-        // timing — a server-side 302 does not produce its own loadcommit event).
+            return $this->samlRedirectPage($request);
+        }
+
+        // Fallback for any non-throw redirect (guard implementations that return
+        // a RedirectResponse rather than throwing).
         if ($request->routeIs('gaia.embedded-setup') && $response->isRedirect()) {
-            $loginUrl = json_encode(
-                $response->getTargetUrl(),
-                JSON_UNESCAPED_SLASHES | JSON_HEX_TAG
-            );
-
-            return response(
-                '<!doctype html><html><head><meta charset="utf-8"></head><body>'
-                . "<script>window.location.replace($loginUrl);</script>"
-                . '</body></html>',
-                200
-            )->header('Content-Type', 'text/html; charset=utf-8')
-             ->header('google-accounts-saml', 'start');
+            return $this->samlRedirectPage($request);
         }
 
         // Belt-and-suspenders: also emit the header on the login page itself.
@@ -94,6 +92,33 @@ class GaiaSamlMode
         }
 
         return $response;
+    }
+
+    /**
+     * Return the HTML intermediate page that arms SAML mode on ChromeOS.
+     *
+     * See the class docblock for the full explanation. Short version: a JS
+     * redirect (not a 302) is required because only a real HTML response gets its
+     * own loadcommit, which is what sets isSamlPage_ = true before /login's
+     * document_start fires and queries getSAMLFlag.
+     */
+    private function samlRedirectPage(Request $request): Response
+    {
+        // Mirror redirect()->guest(): store the intended URL so isGaiaFlow()
+        // returns true when the browser subsequently loads /login.
+        if ($request->hasSession()) {
+            $request->session()->put('url.intended', $request->fullUrl());
+        }
+
+        $loginUrl = json_encode(route('login'), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG);
+
+        return response(
+            '<!doctype html><html><head><meta charset="utf-8"></head><body>'
+            . "<script>window.location.replace($loginUrl);</script>"
+            . '</body></html>',
+            200
+        )->header('Content-Type', 'text/html; charset=utf-8')
+         ->header('google-accounts-saml', 'start');
     }
 
     private function isGaiaFlow(Request $request): bool

--- a/app/Http/Middleware/GaiaSamlMode.php
+++ b/app/Http/Middleware/GaiaSamlMode.php
@@ -4,7 +4,6 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -65,53 +64,18 @@ class GaiaSamlMode
 {
     public function handle(Request $request, Closure $next): Response
     {
-        // For the GAIA embedded setup route, handle unauthenticated requests HERE
-        // before calling $next() — not after. Laravel's Authenticate middleware
-        // throws AuthenticationException rather than returning a RedirectResponse,
-        // so any post-$next() check is unreachable for unauthenticated requests.
-        // StartSession runs before us in the web group, so Auth::check() correctly
-        // reads session state without needing $next() to run first.
-        if ($request->routeIs('gaia.embedded-setup') && ! Auth::check()) {
-            return $this->samlRedirectPage($request);
-        }
-
         $response = $next($request);
 
-        // Belt-and-suspenders: also emit the header on the login page itself.
+        // Belt-and-suspenders: also emit the header on the login page.
         // Keeps pendingIsSamlPage_ = true throughout the /login navigation so
-        // isSamlPage_ remains true at /login's loadcommit and beyond.
+        // isSamlPage_ remains true at /login's own loadcommit and beyond.
+        // The primary SAML header is emitted by EmbeddedSetupController on the
+        // bootstrap page that precedes /login.
         if ($request->routeIs('login') && $this->isGaiaFlow($request)) {
             $response->headers->set('google-accounts-saml', 'start');
         }
 
         return $response;
-    }
-
-    /**
-     * Return the HTML intermediate page that arms SAML mode on ChromeOS.
-     *
-     * See the class docblock for the full explanation. Short version: a JS
-     * redirect (not a 302) is required because only a real HTML response gets its
-     * own loadcommit, which is what sets isSamlPage_ = true before /login's
-     * document_start fires and queries getSAMLFlag.
-     */
-    private function samlRedirectPage(Request $request): Response
-    {
-        // Mirror redirect()->guest(): store the intended URL so isGaiaFlow()
-        // returns true when the browser subsequently loads /login.
-        if ($request->hasSession()) {
-            $request->session()->put('url.intended', $request->fullUrl());
-        }
-
-        $loginUrl = json_encode(route('login'), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG);
-
-        return response(
-            '<!doctype html><html><head><meta charset="utf-8"></head><body>'
-            . "<script>window.location.replace($loginUrl);</script>"
-            . '</body></html>',
-            200
-        )->header('Content-Type', 'text/html; charset=utf-8')
-         ->header('google-accounts-saml', 'start');
     }
 
     private function isGaiaFlow(Request $request): bool

--- a/routes/gaia.php
+++ b/routes/gaia.php
@@ -39,10 +39,15 @@ Route::middleware(['auth:api', 'oidc.blacklist'])
     ->get('oauth2/v1/userinfo', UserinfoController::class)
     ->name('userinfo');
 
-// Sign-in webview page (GAIA origin) — served to the OOBE <webview>. Behind
-// web/auth: an unauthenticated device hits aut.hair's normal login (creds +
-// 2FA) first, then returns here. The google-accounts-signin header + oauth_code
-// cookie ride on this response; the page posts userInfo -> closeView.
-Route::middleware(['web', 'auth'])
+// Sign-in webview page (GAIA origin) — served to the OOBE <webview>.
+// Auth is handled inside the controller: unauthenticated requests receive the
+// SAML bootstrap page (google-accounts-saml: start + JS redirect to /login),
+// which gives ChromeOS the loadcommit it needs to set isSamlPage_ = true before
+// /login's document_start fires. Authenticated requests get the normal
+// google-accounts-signin header + oauth_code cookie completion page.
+// We do NOT use the `auth` middleware here because Authenticate throws
+// AuthenticationException rather than returning a response, which makes it
+// impossible to intercept and replace with the SAML bootstrap page.
+Route::middleware('web')
     ->get('embedded/setup/v2/chromeos', EmbeddedSetupController::class)
     ->name('embedded-setup');

--- a/tests/Feature/GaiaEmbeddedSetupTest.php
+++ b/tests/Feature/GaiaEmbeddedSetupTest.php
@@ -29,11 +29,20 @@ class GaiaEmbeddedSetupTest extends TestCase
         ]);
     }
 
-    public function test_unauthenticated_device_is_redirected_to_login(): void
+    public function test_unauthenticated_device_gets_saml_bootstrap_page(): void
     {
-        // No session => aut.hair's real login runs first (creds + 2FA), then the
-        // device is sent back here.
-        $this->get(route('gaia.embedded-setup'))->assertRedirect();
+        // No session => the controller returns a 200 HTML page (not a 302) that
+        // carries google-accounts-saml: start and JS-redirects to /login.
+        // A server-side 302 would have no loadcommit of its own, so isSamlPage_
+        // would be false when /login's document_start fires and the
+        // PasswordInputScraper would never initialize — the device powerwashes.
+        $response = $this->get(route('gaia.embedded-setup'));
+
+        $response->assertStatus(200);
+        $this->assertSame('start', $response->headers->get('google-accounts-saml'));
+        $response->assertSee('window.location.replace', false);
+        // Controller stores url.intended so isGaiaFlow() fires on /login.
+        $response->assertSessionHas('url.intended');
     }
 
     public function test_authenticated_page_emits_the_signin_contract(): void

--- a/tests/Feature/GaiaSamlModeTest.php
+++ b/tests/Feature/GaiaSamlModeTest.php
@@ -50,7 +50,7 @@ class GaiaSamlModeTest extends TestCase
         // JS redirect is required — a meta-refresh or server 302 won't produce the
         // intermediate loadcommit that sets isSamlPage_ = true.
         $setup->assertSee('window.location.replace', false);
-        // Auth middleware still ran and stored url.intended before we intercepted.
+        // Controller stores url.intended directly so isGaiaFlow() fires on /login.
         $setup->assertSessionHas('url.intended');
 
         // The login page (same session) also emits the SAML header (belt-and-

--- a/tests/Feature/GaiaSamlModeTest.php
+++ b/tests/Feature/GaiaSamlModeTest.php
@@ -9,8 +9,10 @@ use Tests\TestCase;
 /**
  * SAML mode for the openFyde/ChromeOS GAIA OOBE flow: ChromeOS only captures the
  * typed password (the cryptohome factor that prevents the silent powerwash) when
- * the login page emits `google-accounts-saml` and runs the gaia_saml_api
- * handshake. That must happen ONLY inside the GAIA flow, never for normal logins.
+ * the login page emits `google-accounts-saml: start`. The PasswordInputScraper
+ * injected by ChromeOS then auto-scrapes the password field and stores it on the
+ * handler side, where it persists across the /login → /embedded/setup navigation.
+ * That must happen ONLY inside the GAIA flow, never for normal logins.
  */
 class GaiaSamlModeTest extends TestCase
 {
@@ -32,26 +34,32 @@ class GaiaSamlModeTest extends TestCase
 
         $response->assertStatus(200);
         $this->assertNull($response->headers->get('google-accounts-saml'));
-        $response->assertDontSee('gaia_saml_api', false);
     }
 
     public function test_embedded_setup_marks_the_flow_and_login_enters_saml_mode(): void
     {
-        // An unauthenticated device hitting the GAIA entry point is bounced to
-        // login; `auth` records the GAIA page as the intended URL.
-        $this->get(route('gaia.embedded-setup'))
-            ->assertRedirect(route('login'))
-            ->assertSessionHas('url.intended');
+        // An unauthenticated device hitting the GAIA entry point must receive an
+        // HTML page (not a 302) that carries google-accounts-saml: start and uses a
+        // JavaScript redirect to /login. A server-side 302 would skip the loadcommit
+        // for /embedded/setup; without that loadcommit, isSamlPage_ is false when
+        // /login's document_start fires and the PasswordInputScraper never inits.
+        $setup = $this->get(route('gaia.embedded-setup'));
 
-        // The login page (same session) now emits the SAML header and the
-        // Credentials Passing API handshake so ChromeOS captures the password.
+        $setup->assertStatus(200);
+        $this->assertSame('start', $setup->headers->get('google-accounts-saml'));
+        // JS redirect is required — a meta-refresh or server 302 won't produce the
+        // intermediate loadcommit that sets isSamlPage_ = true.
+        $setup->assertSee('window.location.replace', false);
+        // Auth middleware still ran and stored url.intended before we intercepted.
+        $setup->assertSessionHas('url.intended');
+
+        // The login page (same session) also emits the SAML header (belt-and-
+        // suspenders: keeps pendingIsSamlPage_ = true at /login's loadcommit).
         $login = $this->get('/login');
 
         $login->assertStatus(200);
-        // Must be exactly "start" — ChromeOS matches the value, not mere presence.
         $this->assertSame('start', $login->headers->get('google-accounts-saml'));
-        $login->assertSee('gaia_saml_api', false);
-        $login->assertSee('KEY_TYPE_PASSWORD_PLAIN', false);
+        $login->assertDontSee('gaia_saml_api', false);
     }
 
     public function test_the_completion_page_is_not_in_saml_mode(): void


### PR DESCRIPTION
## Summary

- **Root cause of powerwash (third iteration):** ChromeOS's `PasswordInputScraper` is gated by `getSAMLFlag`, which queries `isSamlPage_` at `document_start`. In Chromium's architecture, `document_start` content scripts run **before** `loadcommit` fires for the same page — so `isSamlPage_` always reflects the *previous* page's `loadcommit`, not the current page's `pendingIsSamlPage_`. With a server-side 302 (`/embedded/setup → /login`), `/embedded/setup` has no `loadcommit` of its own, so `isSamlPage_` is `false` when `/login`'s `document_start` fires. The scraper never initializes, `password_` stays null, ChromeOS arms `kSilentPowerwash`.
- **Fix:** when an unauthenticated webview hits `/embedded/setup`, return a 200 HTML page with `google-accounts-saml: start` that `window.location.replace()`-redirects to `/login`. This gives ChromeOS a `loadcommit` for `/embedded/setup` (`isSamlPage_ = true`). When `/login` subsequently loads, its `document_start` fires before `/login`'s own `loadcommit` — but `isSamlPage_` is now `true` from `/embedded/setup`'s loadcommit, so the scraper initializes and captures the typed password.
- **No impact on normal logins:** the intermediate HTML page only fires for `routeIs('gaia.embedded-setup') && $response->isRedirect()`. Normal `/login` visits (no GAIA session) are unaffected. The `google-accounts-saml` header is a ChromeOS-internal concept; non-ChromeOS browsers silently ignore it.
- This mirrors how real enterprise SAML works: GAIA (`accounts.google.com`) emits the header on its own HTML page (not a 302), gets its own `loadcommit`, and the actual IdP's `document_start` then sees `isSamlPage_ = true` from GAIA's prior loadcommit. Previous attempts (v1.6.4: `gaia_saml_api` injection, v1.6.5: header on `/login` only) both failed because they didn't address this timing constraint.

## Code references (openFyde r132 Chromium tree)

- `saml_handler.js:572` — `isSamlPage_ = pendingIsSamlPage_` (only at loadcommit)
- `saml_handler.js:1026` — `onGetSAMLFlag_` returns `this.isSamlPage_` (not `pendingIsSamlPage_`)
- `saml_injected.js:214` — `getSAMLFlag` sent at `document_start` (before loadcommit)
- `saml_handler.js:990` — `onUpdatePassword_` only stores if `this.isSamlPage_`

## Test plan

- [ ] Deploy to device; complete OOBE sign-in; reboot — device should NOT powerwash
- [ ] Normal browser login to `aut.hair/login` (no GAIA flow) — no `google-accounts-saml` header, no JS redirect
- [ ] CI: `GaiaSamlModeTest` — `/embedded/setup` unauthenticated returns 200 with SAML header + `window.location.replace`; `/login` returns 200 with SAML header; completion page has no SAML header